### PR TITLE
[NAE-1559] Keyword 'this' in event actions

### DIFF
--- a/src/test/groovy/com/netgrif/application/engine/importer/ImporterTestGroovy.groovy
+++ b/src/test/groovy/com/netgrif/application/engine/importer/ImporterTestGroovy.groovy
@@ -10,6 +10,7 @@ import com.netgrif.application.engine.petrinet.service.interfaces.IPetriNetServi
 import com.netgrif.application.engine.startup.ImportHelper
 import com.netgrif.application.engine.startup.SuperCreator
 import com.netgrif.application.engine.workflow.domain.Case
+import com.netgrif.application.engine.workflow.service.interfaces.ITaskService
 import com.netgrif.application.engine.workflow.service.interfaces.IWorkflowService
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
@@ -30,6 +31,9 @@ class ImporterTestGroovy {
 
     @Autowired
     private IPetriNetService petriNetService
+
+    @Autowired
+    private ITaskService taskService
 
     @Autowired
     private SuperCreator superCreator
@@ -67,6 +71,18 @@ class ImporterTestGroovy {
         assert upserted.present
 
         assert upserted.get().creationDate == net.get().creationDate
+    }
+
+    @Test
+
+    void thisKeywordInDataEventsTest() {
+        PetriNet net = petriNetService.importPetriNet(new ClassPathResource("/this_kw_test.xml").getInputStream(), VersionType.MAJOR, superCreator.getLoggedSuper()).getNet()
+
+        assert net != null
+        Case testCase = workflowService.createCase(net.stringId, "Test case", "", superCreator.loggedSuper).getCase()
+        taskService.assignTask(testCase.getTasks().toList().get(0).getTask())
+        testCase = workflowService.findOne(testCase.getStringId())
+        assert testCase.getDataField("tester_text_field").getValue().equals("Hello world!")
     }
 
     @Test

--- a/src/test/groovy/com/netgrif/application/engine/importer/ImporterTestGroovy.groovy
+++ b/src/test/groovy/com/netgrif/application/engine/importer/ImporterTestGroovy.groovy
@@ -74,7 +74,6 @@ class ImporterTestGroovy {
     }
 
     @Test
-
     void thisKeywordInDataEventsTest() {
         PetriNet net = petriNetService.importPetriNet(new ClassPathResource("/this_kw_test.xml").getInputStream(), VersionType.MAJOR, superCreator.getLoggedSuper()).getNet()
 

--- a/src/test/resources/this_kw_test.xml
+++ b/src/test/resources/this_kw_test.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:noNamespaceSchemaLocation="../../main/resources/petriNets/petriflow_schema.xsd">
+    <id>this_kw_test</id>
+    <initials>TKW</initials>
+    <title>This keyword test net</title>
+    <defaultRole>true</defaultRole>
+    <transitionRole>false</transitionRole>
+    <!-- TRANSACTIONS -->
+    <!-- ROLES -->
+    <!-- PROCESS ROLE REFS -->
+    <!-- PROCESS USER REFS -->
+    <!-- DATA -->
+    <data type="text">
+        <id>text_field</id>
+        <title></title>
+        <event type="set">
+            <id>ev</id>
+            <actions phase="pre">
+                <action>
+                    tester_text_field: f.tester_text_field,
+                    tf: f.this;
+                    change tester_text_field value { tf.value }
+                </action>
+            </actions>
+        </event>
+    </data>
+
+    <data type="text">
+        <id>tester_text_field</id>
+        <title></title>
+    </data>
+    <!-- I18NS -->
+    <!-- TRANSITIONS -->
+    <transition>
+        <id>t1</id>
+        <x>340</x>
+        <y>140</y>
+        <layout>
+            <offset>0</offset>
+        </layout>
+        <label></label>
+        <dataGroup>
+            <id>DataGroup</id>
+            <layout>grid</layout>
+            <dataRef>
+                <id>text_field</id>
+                <logic>
+                    <behavior>editable</behavior>
+                </logic>
+                <layout>
+                    <x>0</x>
+                    <y>0</y>
+                    <rows>1</rows>
+                    <cols>1</cols>
+                    <offset>0</offset>
+                    <template>material</template>
+                    <appearance>outline</appearance>
+                </layout>
+            </dataRef>
+        </dataGroup>
+        <event type="assign">
+            <id>t1_assign</id>
+            <actions phase="pre">
+                <action>
+                    text_field: f.text_field;
+                    change text_field value { "Hello world!"; }
+                </action>
+            </actions>
+        </event>
+    </transition>
+    <!-- PLACES -->
+    <!-- ARCS -->
+</document>


### PR DESCRIPTION
# Description

- replaced parseAction function for actions for fields when parsing data events

Fixes [NAE-1559]

## Dependencies

- No new dependencies were introduced

## How Has Been This Tested?

- [ImporterTestGroovy.thisKeywordInDataEventsTest](https://github.com/netgrif/application-engine/blob/NAE-1559_2/src/test/groovy/com/netgrif/application/engine/importer/ImporterTestGroovy.groovy#L77)

### Test Configuration

- Linux
- Java 11

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes have been checked, personally or remotely, with @renczesnetgrif 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes:
    - [x] Lint test
    - [x] Unit tests
    - [x] Integration tests
- [x] I have checked my contribution with code analysis tools:
    - [x] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_application-engine)
    - [x] [Snyk](https://app.snyk.io/org/netgrif/project/ea82b3b8-658d-41f5-89a7-76cd600da01f)
- [x] I have made corresponding changes to the documentation:
    - [x] Developer documentation
    - [x] User Guides
    - [x] Migration Guides


[NAE-1559]: https://netgrif.atlassian.net/browse/NAE-1559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ