### PR TITLE
[NAE-1600] Parallel auto-trigger tasks

### DIFF
--- a/src/main/java/com/netgrif/application/engine/workflow/service/TaskService.java
+++ b/src/main/java/com/netgrif/application/engine/workflow/service/TaskService.java
@@ -175,6 +175,7 @@ public class TaskService implements ITaskService {
         useCase = workflowService.save(useCase);
         save(task);
         reloadTasks(useCase);
+        useCase = workflowService.findOne(useCase.getStringId());
         return useCase;
     }
 


### PR DESCRIPTION
# Description

If there are two transitions in net that are paralel, the second one is executed two times, however there is only one token in its source place.

Fixes [NAE-1600]

## Dependencies

No new dependencies were introduced.

### Third party dependencies

No new dependencies were introduced.

### Blocking Pull requests

There are no dependencies on other PR.

## How Has Been This Tested?

This was tested manually using frontend and petri net attached to Jira task.

### Test Configuration

This was tested on macOS Monterey 12.2.1 using Java 11 and Spring boot 2.6.2

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes have been checked, personally or remotely, with @timbez
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes:
    - [x] Lint test
    - [x] Unit tests
    - [x] Integration tests
- [x] I have checked my contribution with code analysis tools:
    - [x] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_application-engine)
    - [x] [Snyk](https://app.snyk.io/org/netgrif/project/ea82b3b8-658d-41f5-89a7-76cd600da01f)
- [x] I have made corresponding changes to the documentation:
    - [x] Developer documentation
    - [x] User Guides
    - [x] Migration Guides


[NAE-1600]: https://netgrif.atlassian.net/browse/NAE-1600?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ