### PR TITLE
[NAE-1614] Advanced search substring query

### DIFF
--- a/src/main/java/com/netgrif/application/engine/elastic/service/ElasticCaseService.java
+++ b/src/main/java/com/netgrif/application/engine/elastic/service/ElasticCaseService.java
@@ -75,8 +75,8 @@ public class ElasticCaseService extends ElasticViewPermissionService implements 
 
     private Map<String, Float> fullTextFieldMap = ImmutableMap.of(
             "title.keyword", 2f,
-            "authorName.keyword", 1f,
-            "authorEmail.keyword", 1f,
+            "authorName", 1f,
+            "authorEmail", 1f,
             "visualId.keyword", 2f
     );
 
@@ -387,7 +387,7 @@ public class ElasticCaseService extends ElasticViewPermissionService implements 
 
         String populatedQuery = request.query.replaceAll(ElasticQueryConstants.USER_ID_TEMPLATE, user.getId().toString());
 
-        query.must(queryStringQuery(populatedQuery));
+        query.must(queryStringQuery(populatedQuery).allowLeadingWildcard(true).analyzeWildcard(true));
     }
 
     /**


### PR DESCRIPTION
# Description

Frontend filter does not work properly when searching for substring. The problem was that Elasticsearch was searching for the substring as a whole word, and not part of substring.

Fixes [NAE-1614]

## Dependencies

No new dependencies were introduced

### Third party dependencies

No new dependencies were introduced

### Blocking Pull requests

There are no dependencies on other PR

## How Has Been This Tested?

This was tested manually.

### Test Configuration

| Name                | Tested on |
|---------------------| --------- |
| OS                  |    macOS Monterey 12.2.1       |
| Runtime             |  Java 11       |
| Dependency Manager  |  Maven 3.8.6        |
| Framework version   |   Spring Boot 2.6.2     |

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes have been checked, personally or remotely, with @mladoniczky @machacjozef 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes:
    - [x] Lint test
    - [x] Unit tests
    - [x] Integration tests
- [x] I have checked my contribution with code analysis tools:
    - [ ] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_application-engine)
    - [x] [Snyk](https://app.snyk.io/org/netgrif)
- [x] I have made corresponding changes to the documentation:
    - [x] Developer documentation
    - [x] User Guides
    - [x] Migration Guides

[NAE-1614]: https://netgrif.atlassian.net/browse/NAE-1614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ  