### PR TITLE
[NAE-1596] Nets with transitions without titles cannot be read

### DIFF
--- a/src/main/java/com/netgrif/application/engine/importer/service/Importer.java
+++ b/src/main/java/com/netgrif/application/engine/importer/service/Importer.java
@@ -485,7 +485,7 @@ public class Importer {
 
         Transition transition = new Transition();
         transition.setImportId(importTransition.getId());
-        transition.setTitle(toI18NString(importTransition.getLabel()) != null ? toI18NString(importTransition.getLabel()) : new I18nString(""));
+        transition.setTitle(importTransition.getLabel() != null ? toI18NString(importTransition.getLabel()) : new I18nString(""));
         transition.setPosition(importTransition.getX(), importTransition.getY());
         if (importTransition.getLayout() != null) {
             transition.setLayout(new TaskLayout(importTransition));

--- a/src/main/java/com/netgrif/application/engine/importer/service/Importer.java
+++ b/src/main/java/com/netgrif/application/engine/importer/service/Importer.java
@@ -485,7 +485,7 @@ public class Importer {
 
         Transition transition = new Transition();
         transition.setImportId(importTransition.getId());
-        transition.setTitle(toI18NString(importTransition.getLabel()));
+        transition.setTitle(toI18NString(importTransition.getLabel()) != null ? toI18NString(importTransition.getLabel()) : new I18nString(""));
         transition.setPosition(importTransition.getX(), importTransition.getY());
         if (importTransition.getLayout() != null) {
             transition.setLayout(new TaskLayout(importTransition));

--- a/src/test/groovy/com/netgrif/application/engine/petrinet/domain/ImporterTest.groovy
+++ b/src/test/groovy/com/netgrif/application/engine/petrinet/domain/ImporterTest.groovy
@@ -231,4 +231,17 @@ class ImporterTest {
         }
         assert net.places.size() == 0
     }
+
+    @Test
+    void createTransitionNoLabel(){
+        PetriNet net = petriNetService.importPetriNet(new FileInputStream("src/test/resources/importTest/NoLabel.xml"), VersionType.MAJOR, superCreator.getLoggedSuper()).getNet()
+        assert net
+        PetriNet importNet = petriNetService.findByImportId(net.getImportId()).get()
+        assert importNet
+        assert importNet.getTransition("1").getTitle()
+        assert importNet.getTransition("layout").getTitle()
+        assert importNet.getTransition("layout").getTitle().equals("")
+
+    }
+
 }

--- a/src/test/resources/importTest/NoLabel.xml
+++ b/src/test/resources/importTest/NoLabel.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<document>
+    <id>ImportTest</id>
+    <version>1.0.0</version>
+    <initials>imp</initials>
+    <title>Import Test</title>
+    <defaultRole>true</defaultRole>
+    <anonymousRole>false</anonymousRole>
+    <role>
+        <id>system</id>
+        <title>System</title>
+    </role>
+    <data type="text">
+        <id>variable1</id>
+        <title>Attribute1</title>
+    </data>
+
+    <transition>
+        <id>1</id>
+        <label>Test</label>
+        <x>0</x>
+        <y>0</y>
+        <roleRef>
+            <id>system</id>
+            <logic>
+                <perform>true</perform>
+            </logic>
+        </roleRef>
+        <dataGroup>
+            <id>dg</id>
+            <layout>legacy</layout>
+            <dataRef>
+                <id>variable1</id>
+                <logic>
+                    <behavior>editable</behavior>
+                </logic>
+            </dataRef>
+        </dataGroup>
+    </transition>
+
+    <transition>
+        <id>layout</id>
+        <x>0</x>
+        <y>0</y>
+        <roleRef>
+            <id>system</id>
+            <logic>
+                <perform>true</perform>
+            </logic>
+        </roleRef>
+        <dataGroup>
+            <id>dg</id>
+            <layout>legacy</layout>
+            <dataRef>
+                <id>variable1</id>
+                <logic>
+                    <behavior>editable</behavior>
+                </logic>
+            </dataRef>
+        </dataGroup>
+    </transition>
+
+</document>

--- a/src/test/resources/importTest/NoLabel.xml
+++ b/src/test/resources/importTest/NoLabel.xml
@@ -6,10 +6,6 @@
     <title>Import Test</title>
     <defaultRole>true</defaultRole>
     <anonymousRole>false</anonymousRole>
-    <role>
-        <id>system</id>
-        <title>System</title>
-    </role>
     <data type="text">
         <id>variable1</id>
         <title>Attribute1</title>
@@ -20,12 +16,6 @@
         <label>Test</label>
         <x>0</x>
         <y>0</y>
-        <roleRef>
-            <id>system</id>
-            <logic>
-                <perform>true</perform>
-            </logic>
-        </roleRef>
         <dataGroup>
             <id>dg</id>
             <layout>legacy</layout>
@@ -42,12 +32,6 @@
         <id>layout</id>
         <x>0</x>
         <y>0</y>
-        <roleRef>
-            <id>system</id>
-            <logic>
-                <perform>true</perform>
-            </logic>
-        </roleRef>
         <dataGroup>
             <id>dg</id>
             <layout>legacy</layout>


### PR DESCRIPTION
# Description

Fixes [NAE-1596]

## Dependencies

No new dependencies were introduced

### Third party dependencies

No new dependencies were introduced

### Blocking Pull requests

There are no dependencies on other PR

## How Has Been This Tested?

- [ImporterTest.createTransitionNoLabel](https://github.com/netgrif/application-engine/blob/NAE-1596/src/test/groovy/com/netgrif/application/engine/petrinet/domain/ImporterTest.groovy#L236)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes have been checked, personally or remotely, with @SamuelPalaj 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes:
    - [x] Lint test
    - [x] Unit tests
    - [x] Integration tests
- [x] I have checked my contribution with code analysis tools:
    - [x] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_application-engine)
    - [x] [Snyk](https://app.snyk.io/org/netgrif/project/ea82b3b8-658d-41f5-89a7-76cd600da01f)
- [x] I have made corresponding changes to the documentation:
    - [x] Developer documentation
    - [x] User Guides
    - [x] Migration Guides


[NAE-1596]: https://netgrif.atlassian.net/browse/NAE-1596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ