### PR TITLE
[NAE-1598] DataGroups without ID cannot be saved into mongo

### DIFF
--- a/src/main/java/com/netgrif/application/engine/importer/service/Importer.java
+++ b/src/main/java/com/netgrif/application/engine/importer/service/Importer.java
@@ -702,7 +702,11 @@ public class Importer {
     protected void addDataGroup(Transition transition, com.netgrif.application.engine.importer.model.DataGroup importDataGroup) throws MissingIconKeyException {
         String alignment = importDataGroup.getAlignment() != null ? importDataGroup.getAlignment().value() : "";
         DataGroup dataGroup = new DataGroup();
-        dataGroup.setImportId(importDataGroup.getId());
+
+        if (importDataGroup.getId() != null && importDataGroup.getId().length() > 0)
+            dataGroup.setImportId(importDataGroup.getId());
+        else
+            dataGroup.setImportId(transition.getImportId() + "_" + System.currentTimeMillis());
 
         dataGroup.setLayout(new DataGroupLayout(importDataGroup));
 

--- a/src/main/java/com/netgrif/application/engine/importer/service/Importer.java
+++ b/src/main/java/com/netgrif/application/engine/importer/service/Importer.java
@@ -321,7 +321,7 @@ public class Importer {
         mapping.getRoleRef().forEach(roleRef -> addRoleLogic(transition, roleRef));
         mapping.getDataRef().forEach(dataRef -> addDataLogic(transition, dataRef));
         for (com.netgrif.application.engine.importer.model.DataGroup dataGroup : mapping.getDataGroup()) {
-            addDataGroup(transition, dataGroup);
+            addDataGroup(transition, dataGroup, mapping.getDataGroup().indexOf(dataGroup));
         }
         mapping.getTrigger().forEach(trigger -> addTrigger(transition, trigger));
     }
@@ -528,7 +528,7 @@ public class Importer {
         }
         if (importTransition.getDataGroup() != null) {
             for (com.netgrif.application.engine.importer.model.DataGroup dataGroup : importTransition.getDataGroup()) {
-                addDataGroup(transition, dataGroup);
+                addDataGroup(transition, dataGroup, importTransition.getDataGroup().indexOf(dataGroup));
             }
         }
 
@@ -699,14 +699,14 @@ public class Importer {
     }
 
     @Transactional
-    protected void addDataGroup(Transition transition, com.netgrif.application.engine.importer.model.DataGroup importDataGroup) throws MissingIconKeyException {
+    protected void addDataGroup(Transition transition, com.netgrif.application.engine.importer.model.DataGroup importDataGroup, int index) throws MissingIconKeyException {
         String alignment = importDataGroup.getAlignment() != null ? importDataGroup.getAlignment().value() : "";
         DataGroup dataGroup = new DataGroup();
 
         if (importDataGroup.getId() != null && importDataGroup.getId().length() > 0)
             dataGroup.setImportId(importDataGroup.getId());
         else
-            dataGroup.setImportId(transition.getImportId() + "_" + System.currentTimeMillis());
+            dataGroup.setImportId(transition.getImportId() + "_dg_" + index);
 
         dataGroup.setLayout(new DataGroupLayout(importDataGroup));
 


### PR DESCRIPTION
# Description

If data group has no ID, it is not possible to import the Petri Net. Now, if there is o ID provided for a single data group, the importer will automatically create one according to transition ID and timestamp.

Fixes [NAE-1598]

## Dependencies

No new dependencies were introduced.

### Third party dependencies

No new dependencies were introduced.

### Blocking Pull requests

There are no dependencies on other PR.

## How Has Been This Tested?

This was tested manually when importing the provided XML in the Jira task.

### Test Configuration

| Name                | Tested on |
|---------------------| --------- |
| OS                  |   macOS Monterey 12.2.1        |
| Runtime             |  Java 11        |
| Dependency Manager  |  Maven 3.8.4         |
| Framework version   |  Spring Boot 2.6.2        |
| Run parameters      |           |
| Other configuration |           |

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes have been checked, personally or remotely, with @minop 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes:
    - [ ] Lint test
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] I have checked my contribution with code analysis tools:
    - [ ] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_application-engine)
    - [ ] [Snyk](https://app.snyk.io/org/netgrif/project/ea82b3b8-658d-41f5-89a7-76cd600da01f)
- [x] I have made corresponding changes to the documentation:
    - [x] Developer documentation
    - [x] User Guides
    - [x] Migration Guides
