### PR TITLE
[NAE-1584] Remove petriflow schema

### DIFF
--- a/docs/_media/roles/usersRef_net.xml
+++ b/docs/_media/roles/usersRef_net.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="petriflow_schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>testing_model</id>
     <initials>TSM</initials>
     <title>Testing Model</title>

--- a/docs/_media/views/Layout-Guide-compacting-example.xml
+++ b/docs/_media/views/Layout-Guide-compacting-example.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://netgrif.github.io/petriflow/petriflow.schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
 	<id>compacting_example</id>
 	<initials>EXP</initials>
 	<title>Compacting example</title>

--- a/docs/_media/views/Layout-Guide-flow-example.xml
+++ b/docs/_media/views/Layout-Guide-flow-example.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="https://modeler.netgrif.com/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>flowExample</id>
     <version>1.0.0</version>
     <initials>FEX</initials>

--- a/docs/_media/views/Layout-Guide-grid-example.xml
+++ b/docs/_media/views/Layout-Guide-grid-example.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="https://modeler.netgrif.com/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>gridExample</id>
     <version>1.0.0</version>
     <initials>GEX</initials>

--- a/docs/_media/views/Layout-Guide-legacy-example.xml
+++ b/docs/_media/views/Layout-Guide-legacy-example.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="https://modeler.netgrif.com/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>legacyExample</id>
     <version>1.0.0</version>
     <initials>LEX</initials>

--- a/docs/events/case_event.md
+++ b/docs/events/case_event.md
@@ -15,7 +15,7 @@ case.
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/netgrif/petriflow/main/petriflow.schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
   <id>case_events</id>
   <title>Case Events example</title>
   <initials>CEE</initials>
@@ -53,7 +53,7 @@ User lists cannot be associated with the create event, since they don't exist be
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/netgrif/petriflow/main/petriflow.schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
   <id>case_events</id>
   <title>Case Events example</title>
   <initials>CEE</initials>
@@ -88,7 +88,7 @@ execution.
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/netgrif/petriflow/main/petriflow.schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
   <id>case_events</id>
   <title>Case Events example</title>
   <initials>CEE</initials>
@@ -126,7 +126,7 @@ User lists can be associated with the delete event
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/netgrif/petriflow/main/petriflow.schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
   <id>case_events</id>
   <title>Case Events example</title>
   <initials>CEE</initials>

--- a/docs/events/process_event.md
+++ b/docs/events/process_event.md
@@ -15,7 +15,7 @@ If you want to change data on another cases, you need to use the `setData` funct
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/netgrif/petriflow/main/petriflow.schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>constructor_destructor</id>
     <title>Constructor and Destructor</title>
     <initials>CAD</initials>

--- a/docs/roles/permissions.md
+++ b/docs/roles/permissions.md
@@ -23,7 +23,7 @@ Since the developer may want to apply these roles to "all" transitions a shortha
 The default and the anonymous role can be applied independently of each other.  
 
 ```
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="petriflow_schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
 	...
 	<defaultRole>true</defaultRole>
 	<anonymousRole>true</anonymousRole>
@@ -234,7 +234,7 @@ In the XML model of the process, you can define roles as child elements of the r
 element. The role is connected to the role reference via the role's ID.
 
 ```
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="petriflow_schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
 	...
 	<role>
 		<id>process_role</id>
@@ -256,7 +256,7 @@ Permission documentation can be found [here](#Permissions). Roles can be referen
 - as a child element of the `document` tag for referencing roles on cases:
 
 ```
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="petriflow_schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
 	...
 	<roleRef>
 		<id>process_role</id>
@@ -272,7 +272,7 @@ Permission documentation can be found [here](#Permissions). Roles can be referen
 - as a child element of the `transition` tag for referencing roles on tasks:
 
 ```
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="petriflow_schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
 	...
 	<transition>
 		...
@@ -296,7 +296,7 @@ given user list) to Petriflow objects and their actions. User list can be define
 defined, as child element of the root **document** element:
 
 ```
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="petriflow_schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
 	...
 	<data type="userList">
 		<id>user_list_1</id>
@@ -316,7 +316,7 @@ Permission documentation can be found [here](#Permissions). User list can be ref
 - as a child element of the `document` tag for referencing user list on cases:
 
 ```
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="petriflow_schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
 	...
 	<userRef>
 		<id>user_list_1</id>
@@ -332,7 +332,7 @@ Permission documentation can be found [here](#Permissions). User list can be ref
 - as a child element of the `transition` tag for referencing user list on tasks:
 
 ```
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="petriflow_schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
 	...
 	<transition>
 		...
@@ -381,7 +381,7 @@ Each reference element has a child element called **caseLogic**, which can be us
 permissions for case created from process as follows:
 
 ```
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="petriflow_schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
 ...
 	<roleRef>
 		<id>process_role</id>
@@ -429,7 +429,7 @@ transition** element. Each reference element has a child element called **logic*
 permissions for task created from transition as follows:
 
 ```
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="petriflow_schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
 	...
 	<transition>
 		...

--- a/pom.xml
+++ b/pom.xml
@@ -639,7 +639,7 @@
                             <packageName>com.netgrif.application.engine.importer.model</packageName>
                             <outputDirectory>${project.build.directory}/generated-sources/java</outputDirectory>
                             <sources>
-                                <source>src/main/resources/petriNets/petriflow_schema.xsd</source>
+                                <source>src/main/resources/https://petriflow.com/petriflow.schema.xsd</source>
                             </sources>
                             <generateEpisode>false</generateEpisode>
                             <clearOutputDir>false</clearOutputDir>

--- a/src/main/groovy/com/netgrif/application/engine/startup/DemoRunner.groovy
+++ b/src/main/groovy/com/netgrif/application/engine/startup/DemoRunner.groovy
@@ -40,14 +40,5 @@ class DemoRunner extends AbstractOrderedCommandLineRunner {
 
     @Override
     void run(String... args) throws Exception {
-        Optional<PetriNet> net = helper.createNet("all_data.xml", VersionType.MAJOR)
-        (1..6).each {it ->
-            def aCase = helper.createCase("Case " + it, net.get())
-            if (it % 2 == 0)
-                aCase.dataSet["text"].value = "Even case"
-            else
-                aCase.dataSet["text"].value = "Odd case"
-            caseRepository.save(aCase)
-        }
     }
 }

--- a/src/main/groovy/com/netgrif/application/engine/startup/DemoRunner.groovy
+++ b/src/main/groovy/com/netgrif/application/engine/startup/DemoRunner.groovy
@@ -3,6 +3,8 @@ package com.netgrif.application.engine.startup
 import com.netgrif.application.engine.elastic.domain.ElasticCaseRepository
 import com.netgrif.application.engine.elastic.domain.ElasticTaskRepository
 import com.netgrif.application.engine.elastic.service.interfaces.IElasticCaseService
+import com.netgrif.application.engine.petrinet.domain.PetriNet
+import com.netgrif.application.engine.petrinet.domain.PetriNetObject
 import com.netgrif.application.engine.petrinet.domain.VersionType
 import com.netgrif.application.engine.workflow.domain.repositories.CaseRepository
 import com.netgrif.application.engine.workflow.domain.repositories.TaskRepository
@@ -38,5 +40,14 @@ class DemoRunner extends AbstractOrderedCommandLineRunner {
 
     @Override
     void run(String... args) throws Exception {
+        Optional<PetriNet> net = helper.createNet("all_data.xml", VersionType.MAJOR)
+        (1..6).each {it ->
+            def aCase = helper.createCase("Case " + it, net.get())
+            if (it % 2 == 0)
+                aCase.dataSet["text"].value = "Even case"
+            else
+                aCase.dataSet["text"].value = "Odd case"
+            caseRepository.save(aCase)
+        }
     }
 }

--- a/src/main/resources/petriNets/all_data.xml
+++ b/src/main/resources/petriNets/all_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="petriflow_schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
 	<id>all_data</id>
 	<title>All Data</title>
 	<initials>ALL</initials>

--- a/src/main/resources/petriNets/datamap.xml
+++ b/src/main/resources/petriNets/datamap.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="https://netgrif.github.io/petriflow/petriflow.schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>taskref_demo2</id>
     <version>1.0.0</version>
     <initials>TRD</initials>

--- a/src/main/resources/petriNets/engine-processes/export_filters.xml
+++ b/src/main/resources/petriNets/engine-processes/export_filters.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/netgrif/petriflow/main/petriflow.schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>export_filters</id>
     <initials>FTE</initials>
     <title name="export_filters">Export of filters</title>

--- a/src/main/resources/petriNets/engine-processes/filter.xml
+++ b/src/main/resources/petriNets/engine-processes/filter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/netgrif/petriflow/main/petriflow.schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>filter</id>
     <initials>FTR</initials>
     <title name="process_title">Filter</title>

--- a/src/main/resources/petriNets/engine-processes/import_filters.xml
+++ b/src/main/resources/petriNets/engine-processes/import_filters.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/netgrif/petriflow/main/petriflow.schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>import_filters</id>
     <initials>FTI</initials>
     <title name="import_filters">Import of filters</title>

--- a/src/main/resources/petriNets/engine-processes/org_group.xml
+++ b/src/main/resources/petriNets/engine-processes/org_group.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../petriflow_schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
 	<id>org_group</id>
 	<version>1.0.0</version>
 	<initials>GRP</initials>

--- a/src/main/resources/petriNets/engine-processes/preference_filter_item.xml
+++ b/src/main/resources/petriNets/engine-processes/preference_filter_item.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../petriflow_schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
 	<id>preference_filter_item</id>
 	<initials>PFI</initials>
 	<title>Preference filter item</title>

--- a/src/main/resources/petriNets/insurance_portal_demo.xml
+++ b/src/main/resources/petriNets/insurance_portal_demo.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="https://netgrif.github.io/petriflow/petriflow.schema.xsd">
+        xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>insurance</id>
     <initials>IPD</initials>
     <title>Insurance Portal Demo</title>

--- a/src/main/resources/petriNets/insurance_role_test.xml
+++ b/src/main/resources/petriNets/insurance_role_test.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="petriflow_schema.xsd">
+        xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <defaultRole>false</defaultRole>
     <!-- ========== GLOBAL ================ -->
     <!--<icon>location_city</icon>-->

--- a/src/main/resources/petriNets/leukemia.xml
+++ b/src/main/resources/petriNets/leukemia.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<document xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:noNamespaceSchemaLocation='https://netgrif.github.io/petriflow/petriflow.schema.xsd'>
+<document xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:noNamespaceSchemaLocation='https://petriflow.com/petriflow.schema.xsd'>
     <id>leukemia</id>
     <version>1.0.0</version>
     <initials>LEU</initials>

--- a/src/main/resources/petriNets/leukemia_en.xml
+++ b/src/main/resources/petriNets/leukemia_en.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<document xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:noNamespaceSchemaLocation='https://netgrif.github.io/petriflow/petriflow.schema.xsd'>
+<document xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:noNamespaceSchemaLocation='https://petriflow.com/petriflow.schema.xsd'>
     <version>1.0.0</version>
     <initials>LEU</initials>
     <title>Protocol on treatment of chronic myelocytic leukemia</title>

--- a/src/main/resources/petriNets/mortgage/address.xml
+++ b/src/main/resources/petriNets/mortgage/address.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://netgrif.github.io/petriflow/petriflow.schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>address</id>
     <initials>ADD</initials>
     <title>Address</title>

--- a/src/main/resources/petriNets/mortgage/financial_data.xml
+++ b/src/main/resources/petriNets/mortgage/financial_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://netgrif.github.io/petriflow/petriflow.schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>financial_data</id>
     <initials>FIN</initials>
     <title>Financial Data</title>

--- a/src/main/resources/petriNets/mortgage/financial_data_doc.xml
+++ b/src/main/resources/petriNets/mortgage/financial_data_doc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://netgrif.github.io/petriflow/petriflow.schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>financial_data_doc</id>
     <initials>FDC</initials>
     <title>Financial Data Doc</title>

--- a/src/main/resources/petriNets/mortgage/financial_data_func.xml
+++ b/src/main/resources/petriNets/mortgage/financial_data_func.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../petriflow_schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>financial_data_func</id>
     <initials>FIN</initials>
     <title>Financial Data</title>

--- a/src/main/resources/petriNets/mortgage/mortgage.xml
+++ b/src/main/resources/petriNets/mortgage/mortgage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://netgrif.github.io/petriflow/petriflow.schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>mortgage</id>
     <initials>MOR</initials>
     <title>Mortgage</title>

--- a/src/main/resources/petriNets/mortgage/mortgage_modeler.xml
+++ b/src/main/resources/petriNets/mortgage/mortgage_modeler.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://netgrif.github.io/petriflow/petriflow.schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>mortgage</id>
     <version>1.0.0</version>
     <initials>MOR</initials>

--- a/src/main/resources/petriNets/mortgage/personal_information.xml
+++ b/src/main/resources/petriNets/mortgage/personal_information.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://netgrif.github.io/petriflow/petriflow.schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>personal_information</id>
     <initials>PER</initials>
     <title>Personal Information</title>

--- a/src/main/resources/petriNets/posudky.xml
+++ b/src/main/resources/petriNets/posudky.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="https://modeler.netgrif.com/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <!-- TRANSACTIONS -->
     <!-- ROLES -->
     <role>

--- a/src/main/resources/petriNets/taskRef-propagation/child.xml
+++ b/src/main/resources/petriNets/taskRef-propagation/child.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="https://modeler.netgrif.com/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>child</id>
     <version>1.0.0</version>
     <initials>CHL</initials>

--- a/src/main/resources/petriNets/taskRef-propagation/parent.xml
+++ b/src/main/resources/petriNets/taskRef-propagation/parent.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="https://netgrif.github.io/petriflow/petriflow.schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>parent</id>
     <version>1.0.0</version>
     <initials>PAR</initials>

--- a/src/main/resources/petriNets/test_model_immediate_data.xml
+++ b/src/main/resources/petriNets/test_model_immediate_data.xml
@@ -1,5 +1,5 @@
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <defaultRole>true</defaultRole>
     <caseName name="case_name">Nový prípad</caseName>
     <!-- ROLES -->

--- a/src/main/resources/petriNets/wizard.xml
+++ b/src/main/resources/petriNets/wizard.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="https://modeler.netgrif.com/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <data type="text" immediate="true">
         <id>text</id>
         <title>text</title>

--- a/src/test/resources/actionref_test.xml
+++ b/src/test/resources/actionref_test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>actionref_test.xml</id>
     <initials>TST</initials>
     <title>Test</title>

--- a/src/test/resources/all_data.xml
+++ b/src/test/resources/all_data.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="petriflow_schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>all_data</id>
     <title>All Data</title>
     <initials>ALL</initials>

--- a/src/test/resources/all_data_pdf.xml
+++ b/src/test/resources/all_data_pdf.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="petriflow_schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>all_data</id>
     <title>All Data</title>
     <initials>ALL</initials>

--- a/src/test/resources/arc_order_test.xml
+++ b/src/test/resources/arc_order_test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="https://modeler.netgrif.com/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>arc_order_test.xml</id>
     <initials>TST</initials>
     <title>Test</title>

--- a/src/test/resources/arc_reference_invalid_test.xml
+++ b/src/test/resources/arc_reference_invalid_test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../../src/main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <!-- TRANSITIONS -->
     <id>arc_ref_invalid_test</id>
     <initials>ARi</initials>

--- a/src/test/resources/arc_reference_test.xml
+++ b/src/test/resources/arc_reference_test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../../src/main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>arc_ref_test</id>
     <initials>ART</initials>
     <title>Arc ref test</title>

--- a/src/test/resources/assignRoleMainNet_test_.xml
+++ b/src/test/resources/assignRoleMainNet_test_.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="https://modeler.netgrif.com/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>main</id>
     <initials>ORG</initials>
     <title>main</title>

--- a/src/test/resources/assignRoleSecondaryNet_test.xml
+++ b/src/test/resources/assignRoleSecondaryNet_test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="https://modeler.netgrif.com/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>secondary</id>
     <initials>ORG</initials>
     <title>secondary</title>

--- a/src/test/resources/assign_cancel_finish_with_Case_test.xml
+++ b/src/test/resources/assign_cancel_finish_with_Case_test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>assign_cancel_finish_with_Case_net</id>
     <initials>TST</initials>
     <title>Test</title>

--- a/src/test/resources/autotrigger_taskref.xml
+++ b/src/test/resources/autotrigger_taskref.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		  xsi:noNamespaceSchemaLocation="https://netgrif.github.io/petriflow/petriflow.schema.xsd">
+		  xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
 	<id>Praca</id>
 	<initials>PRC</initials>
 	<title>Práca</title>

--- a/src/test/resources/case_choices_test.xml
+++ b/src/test/resources/case_choices_test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>test</id>
     <initials>TST</initials>
     <title>Test</title>

--- a/src/test/resources/case_search_test.xml
+++ b/src/test/resources/case_search_test.xml
@@ -1,5 +1,5 @@
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>case_search_test.xml</id>
     <initials>TST</initials>
     <title>Test</title>

--- a/src/test/resources/caseref_test.xml
+++ b/src/test/resources/caseref_test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="https://netgrif.github.io/petriflow/petriflow.schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>caseref_test.xml</id>
     <initials>TST</initials>
     <title>Test</title>

--- a/src/test/resources/change_allowed_nets_action_test.xml
+++ b/src/test/resources/change_allowed_nets_action_test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>test</id>
     <initials>TST</initials>
     <title>Test</title>

--- a/src/test/resources/change_caseref_value_action_test.xml
+++ b/src/test/resources/change_caseref_value_action_test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>change_value</id>
     <initials>TST</initials>
     <title>Test</title>

--- a/src/test/resources/constructor_destructor.xml
+++ b/src/test/resources/constructor_destructor.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>constructor_destructor</id>
     <initials>CAD</initials>
     <title>Constructor and Destructor</title>

--- a/src/test/resources/create_case_locale.xml
+++ b/src/test/resources/create_case_locale.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>currency_test.xml</id>
     <initials>TST</initials>
     <title>Test</title>

--- a/src/test/resources/currency_test.xml
+++ b/src/test/resources/currency_test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>currency_test.xml</id>
     <initials>TST</initials>
     <title>Test</title>

--- a/src/test/resources/data_button_test.xml
+++ b/src/test/resources/data_button_test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>test</id>
     <initials>TST</initials>
     <title>Test</title>

--- a/src/test/resources/data_map.xml
+++ b/src/test/resources/data_map.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>test</id>
     <initials>TST</initials>
     <title name="doc_name">Test</title>

--- a/src/test/resources/data_map_2.xml
+++ b/src/test/resources/data_map_2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>test</id>
     <initials>TST</initials>
     <title>Test</title>

--- a/src/test/resources/data_service_referenced.xml
+++ b/src/test/resources/data_service_referenced.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="https://modeler.netgrif.com/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>referenced</id>
     <version>1.0.0</version>
     <initials>RFD</initials>

--- a/src/test/resources/data_service_taskref.xml
+++ b/src/test/resources/data_service_taskref.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="https://modeler.netgrif.com/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>refering</id>
     <version>1.0.0</version>
     <initials>REF</initials>

--- a/src/test/resources/data_test.xml
+++ b/src/test/resources/data_test.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../main/resources/petriNets/petriflow_schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>1</id>
     <initials>TES</initials>
     <title>Data test</title>

--- a/src/test/resources/data_text_validation.xml
+++ b/src/test/resources/data_text_validation.xml
@@ -1,6 +1,6 @@
 F<?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>test</id>
     <initials>TST</initials>
     <title>Test</title>

--- a/src/test/resources/datagroup_test_layout.xml
+++ b/src/test/resources/datagroup_test_layout.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>datagroup_test</id>
     <initials>DGT</initials>
     <title>Data group test</title>

--- a/src/test/resources/enum_list.xml
+++ b/src/test/resources/enum_list.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>test</id>
     <initials>TST</initials>
     <title>Test</title>

--- a/src/test/resources/enumeration_multichoice_options.xml
+++ b/src/test/resources/enumeration_multichoice_options.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../main/resources/petriNets/petriflow_schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>enumeration_multichoice_options</id>
     <title>Enumeration/multichoice options</title>
     <initials>EMO</initials>

--- a/src/test/resources/event_test.xml
+++ b/src/test/resources/event_test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>test</id>
     <initials>TST</initials>
     <title>Test</title>

--- a/src/test/resources/field_view.xml
+++ b/src/test/resources/field_view.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>test</id>
     <initials>TST</initials>
     <title>Test</title>

--- a/src/test/resources/file_test.xml
+++ b/src/test/resources/file_test.xml
@@ -1,5 +1,5 @@
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>test</id>
     <initials>TST</initials>
     <title>Test</title>

--- a/src/test/resources/file_test_net.xml
+++ b/src/test/resources/file_test_net.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="https://modeler.netgrif.com/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>test</id>
     <initials>TST</initials>
     <title>Test</title>

--- a/src/test/resources/flow.xml
+++ b/src/test/resources/flow.xml
@@ -1,5 +1,5 @@
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="https://netgrif.github.io/petriflow/petriflow.schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>new_model</id>
     <initials>NEW</initials>
     <title>New Model</title>

--- a/src/test/resources/initial_behavior.xml
+++ b/src/test/resources/initial_behavior.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../main/resources/petriNets/petriflow_schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>initial_behavior</id>
     <title>Initial behavior</title>
     <initials>IBH</initials>

--- a/src/test/resources/ipc_bulk.xml
+++ b/src/test/resources/ipc_bulk.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>test</id>
     <initials>TST</initials>
     <title>Test</title>

--- a/src/test/resources/ipc_createCase.xml
+++ b/src/test/resources/ipc_createCase.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>create_case_net</id>
     <initials>TST</initials>
     <title>Test</title>

--- a/src/test/resources/ipc_data.xml
+++ b/src/test/resources/ipc_data.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="https://modeler.netgrif.com/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>test</id>
     <initials>TST</initials>
     <title>Test</title>

--- a/src/test/resources/ipc_group.xml
+++ b/src/test/resources/ipc_group.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="https://modeler.netgrif.com/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>test</id>
     <initials>TST</initials>
     <title>Test</title>

--- a/src/test/resources/ipc_set_data.xml
+++ b/src/test/resources/ipc_set_data.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="https://modeler.netgrif.com/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>test</id>
     <initials>TST</initials>
     <title>Test</title>

--- a/src/test/resources/ipc_task_search.xml
+++ b/src/test/resources/ipc_task_search.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>create_case_net</id>
     <initials>TST</initials>
     <title>Test</title>

--- a/src/test/resources/ipc_transition_role.xml
+++ b/src/test/resources/ipc_transition_role.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>test</id>
     <initials>TST</initials>
     <title>Test</title>

--- a/src/test/resources/ipc_where.xml
+++ b/src/test/resources/ipc_where.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>test</id>
     <initials>TST</initials>
     <title>Test</title>

--- a/src/test/resources/mapping_test.xml
+++ b/src/test/resources/mapping_test.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="../../main/resources/petriNets/petriflow_schema.xsd">
+        xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>test</id>
     <initials>TST</initials>
     <title>Test</title>

--- a/src/test/resources/nae-1272_datagroup_divider_improvement.xml
+++ b/src/test/resources/nae-1272_datagroup_divider_improvement.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="https://modeler.netgrif.com/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>nae_1272</id>
     <initials>NAE</initials>
     <title>NAE-1272 Datagroup divider improvement</title>

--- a/src/test/resources/net_clone.xml
+++ b/src/test/resources/net_clone.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="https://modeler.netgrif.com/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>test</id>
     <initials>TST</initials>
     <title>Test</title>

--- a/src/test/resources/net_import_1.xml
+++ b/src/test/resources/net_import_1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="https://modeler.netgrif.com/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>new_model</id>
     <version>1.0.0</version>
     <initials>NEW</initials>

--- a/src/test/resources/net_import_2.xml
+++ b/src/test/resources/net_import_2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="https://modeler.netgrif.com/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>new_model</id>
     <version>1.0.0</version>
     <initials>NEW</initials>

--- a/src/test/resources/org_group.xml
+++ b/src/test/resources/org_group.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://netgrif.github.io/petriflow/petriflow.schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>org_group</id>
     <version>1.0.0</version>
     <initials>GRP</initials>

--- a/src/test/resources/pdf_test_1.xml
+++ b/src/test/resources/pdf_test_1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>1</id>
     <initials>TES</initials>
     <title>Data test</title>

--- a/src/test/resources/pdf_test_2.xml
+++ b/src/test/resources/pdf_test_2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>test</id>
     <initials>TST</initials>
     <title>Test</title>

--- a/src/test/resources/pdf_test_3.xml
+++ b/src/test/resources/pdf_test_3.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="https://modeler.netgrif.com/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>new_model</id>
     <version>1.0.0</version>
     <initials>PER</initials>

--- a/src/test/resources/petriNets/NAE_1305_Loading_na_set_data_pre_button.xml
+++ b/src/test/resources/petriNets/NAE_1305_Loading_na_set_data_pre_button.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>NAE_1305_Loading_na_set_data_pre_button</id>
     <initials>ALL</initials>
     <title>NAE_1305_Loading_na_set_data_pre_button</title>

--- a/src/test/resources/petriNets/NAE_1382_first_trans_auto.xml
+++ b/src/test/resources/petriNets/NAE_1382_first_trans_auto.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://modeler.netgrif.com/petriflow_schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
 	<id>NAE_1382_first_trans_auto</id>
 	<initials>ERR</initials>
 	<title>New Model</title>

--- a/src/test/resources/petriNets/NAE_1382_first_trans_auto_2.xml
+++ b/src/test/resources/petriNets/NAE_1382_first_trans_auto_2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://netgrif.github.io/petriflow/petriflow.schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
 	<id>NAE_1382_first_trans_auto</id>
 	<initials>ERR</initials>
 	<title>New Model</title>

--- a/src/test/resources/petriNets/action_delegate_concurrency_test.xml
+++ b/src/test/resources/petriNets/action_delegate_concurrency_test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="https://modeler.netgrif.com/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>action_delegate_concurrency_test</id>
     <version>1.0.0</version>
     <initials>TRE</initials>

--- a/src/test/resources/petriNets/all_data_refs.xml
+++ b/src/test/resources/petriNets/all_data_refs.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="petriflow_schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
 	<id>all_data</id>
 	<title>All Data</title>
 	<initials>ALL</initials>

--- a/src/test/resources/petriNets/change_field_value_init.xml
+++ b/src/test/resources/petriNets/change_field_value_init.xml
@@ -1,5 +1,5 @@
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>change_field_value_init</id>
     <title>change_field_value_init</title>
     <defaultRole>true</defaultRole>

--- a/src/test/resources/petriNets/changed_fields_allowed_nets.xml
+++ b/src/test/resources/petriNets/changed_fields_allowed_nets.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="https://modeler.netgrif.com/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>changed_fields_allowed_nets</id>
     <initials>NEW</initials>
     <title>New Model</title>

--- a/src/test/resources/petriNets/data_actions_test.xml
+++ b/src/test/resources/petriNets/data_actions_test.xml
@@ -1,5 +1,5 @@
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>data_actions_test</id>
     <version>1.0.0</version>
     <initials>tst</initials>

--- a/src/test/resources/petriNets/dynamic_case_name_test.xml
+++ b/src/test/resources/petriNets/dynamic_case_name_test.xml
@@ -1,5 +1,5 @@
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>dynamic_choices</id>
     <title>dynamic_choices</title>
     <defaultRole>true</defaultRole>

--- a/src/test/resources/petriNets/dynamic_choices.xml
+++ b/src/test/resources/petriNets/dynamic_choices.xml
@@ -1,5 +1,5 @@
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>dynamic_choices</id>
     <title>dynamic_choices</title>
     <defaultRole>true</defaultRole>

--- a/src/test/resources/petriNets/dynamic_init.xml
+++ b/src/test/resources/petriNets/dynamic_init.xml
@@ -1,5 +1,5 @@
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>dynamic_init</id>
     <title>dynamic_init</title>
     <defaultRole>true</defaultRole>

--- a/src/test/resources/petriNets/dynamic_validations.xml
+++ b/src/test/resources/petriNets/dynamic_validations.xml
@@ -1,5 +1,5 @@
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>dynamic_validations</id>
     <title>dynamic_validations</title>
     <defaultRole>true</defaultRole>

--- a/src/test/resources/petriNets/dynamic_validations_performance_test.xml
+++ b/src/test/resources/petriNets/dynamic_validations_performance_test.xml
@@ -1,5 +1,5 @@
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>dynamic_validations_performance</id>
     <title>dynamic_validations_performance</title>
     <defaultRole>true</defaultRole>

--- a/src/test/resources/petriNets/dynamic_validations_performance_test_comparison.xml
+++ b/src/test/resources/petriNets/dynamic_validations_performance_test_comparison.xml
@@ -1,5 +1,5 @@
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>dynamic_validations_performance_comparison</id>
     <title>dynamic_validations_performance_comparison</title>
     <defaultRole>true</defaultRole>

--- a/src/test/resources/petriNets/function_overloading.xml
+++ b/src/test/resources/petriNets/function_overloading.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>function_overloading</id>
     <initials>FOF</initials>
     <title>Test</title>

--- a/src/test/resources/petriNets/function_overloading_fail.xml
+++ b/src/test/resources/petriNets/function_overloading_fail.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>function_overloading_fail</id>
     <initials>FOF</initials>
     <title>Test</title>

--- a/src/test/resources/petriNets/function_overloading_fail_v2.xml
+++ b/src/test/resources/petriNets/function_overloading_fail_v2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>function_overloading_fail</id>
     <initials>FOF</initials>
     <title>Test</title>

--- a/src/test/resources/petriNets/function_overloading_v2.xml
+++ b/src/test/resources/petriNets/function_overloading_v2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>function_overloading</id>
     <initials>FOF</initials>
     <title>Test</title>

--- a/src/test/resources/petriNets/function_res.xml
+++ b/src/test/resources/petriNets/function_res.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>function_res</id>
     <initials>SFR</initials>
     <title>Test</title>

--- a/src/test/resources/petriNets/function_res_v2.xml
+++ b/src/test/resources/petriNets/function_res_v2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>function_res</id>
     <initials>SFR</initials>
     <title>Test</title>

--- a/src/test/resources/petriNets/function_test.xml
+++ b/src/test/resources/petriNets/function_test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>function_test</id>
     <initials>SFT</initials>
     <title>Test</title>

--- a/src/test/resources/petriNets/function_test_v2.xml
+++ b/src/test/resources/petriNets/function_test_v2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>function_test</id>
     <initials>SFT</initials>
     <title>Test</title>

--- a/src/test/resources/petriNets/groovy_shell_test.xml
+++ b/src/test/resources/petriNets/groovy_shell_test.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://modeler.netgrif.com/petriflow_schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
 	<id>new_model</id>
 	<initials>NEW</initials>
 	<title>New Model</title>

--- a/src/test/resources/petriNets/importer_upsert.xml
+++ b/src/test/resources/petriNets/importer_upsert.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="petriflow_schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>importer_upsert</id>
     <title>importer_upsert</title>
     <initials>IMP</initials>

--- a/src/test/resources/petriNets/mortgage_net.xml
+++ b/src/test/resources/petriNets/mortgage_net.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../petriflow_schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>mortgage</id>
     <initials>MOR</initials>
     <title>Mortgage</title>

--- a/src/test/resources/petriNets/nae_1276_Init_value_as_choice.xml
+++ b/src/test/resources/petriNets/nae_1276_Init_value_as_choice.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>new_init_test</id>
     <initials>NIT</initials>
     <title>New init test</title>

--- a/src/test/resources/petriNets/role_assign_remove_test.xml
+++ b/src/test/resources/petriNets/role_assign_remove_test.xml
@@ -1,5 +1,5 @@
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>role_assign_remove_test</id>
     <title>Role Assign And Remove</title>
     <initials>RAR</initials>

--- a/src/test/resources/petriNets/role_test.xml
+++ b/src/test/resources/petriNets/role_test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="https://modeler.netgrif.com/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>role_test</id>
     <initials>IMP</initials>
     <title>role_test</title>

--- a/src/test/resources/predefinedPermissions/role_permissions_anonymous_role_combined.xml
+++ b/src/test/resources/predefinedPermissions/role_permissions_anonymous_role_combined.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://netgrif.github.io/petriflow/petriflow.schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
 	<id>permissions_test_anonymous_6</id>
 	<initials>PTA</initials>
 	<title>Permissions test anonymous 6</title>

--- a/src/test/resources/predefinedPermissions/role_permissions_anonymous_role_custom.xml
+++ b/src/test/resources/predefinedPermissions/role_permissions_anonymous_role_custom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://netgrif.github.io/petriflow/petriflow.schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
 	<id>permissions_test_anonymous_4</id>
 	<initials>PTA</initials>
 	<title>Permissions test anonymous 4</title>

--- a/src/test/resources/predefinedPermissions/role_permissions_anonymous_role_defined.xml
+++ b/src/test/resources/predefinedPermissions/role_permissions_anonymous_role_defined.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://netgrif.github.io/petriflow/petriflow.schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
 	<id>permissions_test_anonymous_2</id>
 	<initials>PTA</initials>
 	<title>Permissions test anonymous 2</title>

--- a/src/test/resources/predefinedPermissions/role_permissions_anonymous_role_disabled.xml
+++ b/src/test/resources/predefinedPermissions/role_permissions_anonymous_role_disabled.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://netgrif.github.io/petriflow/petriflow.schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
 	<id>permissions_test_anonymous_10</id>
 	<initials>PTA</initials>
 	<title>Permissions test anonymous 10</title>

--- a/src/test/resources/predefinedPermissions/role_permissions_anonymous_role_missing.xml
+++ b/src/test/resources/predefinedPermissions/role_permissions_anonymous_role_missing.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://netgrif.github.io/petriflow/petriflow.schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
 	<id>permissions_test_anonymous_7</id>
 	<initials>PTA</initials>
 	<title>Permissions test anonymous 7</title>

--- a/src/test/resources/predefinedPermissions/role_permissions_anonymous_role_negative.xml
+++ b/src/test/resources/predefinedPermissions/role_permissions_anonymous_role_negative.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://netgrif.github.io/petriflow/petriflow.schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
 	<id>permissions_test_anonymous_5</id>
 	<initials>PTA</initials>
 	<title>Permissions test anonymous 5</title>

--- a/src/test/resources/predefinedPermissions/role_permissions_anonymous_role_reserved.xml
+++ b/src/test/resources/predefinedPermissions/role_permissions_anonymous_role_reserved.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://netgrif.github.io/petriflow/petriflow.schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
 	<id>permissions_test_anonymous_8</id>
 	<initials>PTA</initials>
 	<title>Permissions test anonymous 8</title>

--- a/src/test/resources/predefinedPermissions/role_permissions_anonymous_role_shadowed.xml
+++ b/src/test/resources/predefinedPermissions/role_permissions_anonymous_role_shadowed.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://netgrif.github.io/petriflow/petriflow.schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
 	<id>permissions_test_anonymous_3</id>
 	<initials>PTA</initials>
 	<title>Permissions test anonymous 3</title>

--- a/src/test/resources/predefinedPermissions/role_permissions_anonymous_role_shadowed_userref.xml
+++ b/src/test/resources/predefinedPermissions/role_permissions_anonymous_role_shadowed_userref.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://netgrif.github.io/petriflow/petriflow.schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
 	<id>permissions_test_anonymous_9</id>
 	<initials>PTA</initials>
 	<title>Permissions test anonymous 9</title>

--- a/src/test/resources/predefinedPermissions/role_permissions_anonymous_role_shadowed_usersref.xml
+++ b/src/test/resources/predefinedPermissions/role_permissions_anonymous_role_shadowed_usersref.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://netgrif.github.io/petriflow/petriflow.schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
 	<id>permissions_test_anonymous_11</id>
 	<initials>PTA</initials>
 	<title>Permissions test anonymous 11</title>

--- a/src/test/resources/predefinedPermissions/role_permissions_combined_roles_defined.xml
+++ b/src/test/resources/predefinedPermissions/role_permissions_combined_roles_defined.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://netgrif.github.io/petriflow/petriflow.schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
 	<id>permissions_test_combined_2</id>
 	<initials>PTC</initials>
 	<title>Permissions test combined 2</title>

--- a/src/test/resources/predefinedPermissions/role_permissions_combined_roles_undefined.xml
+++ b/src/test/resources/predefinedPermissions/role_permissions_combined_roles_undefined.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://netgrif.github.io/petriflow/petriflow.schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
 	<id>permissions_test_combined_1</id>
 	<initials>PTC</initials>
 	<title>Permissions test combined 1</title>

--- a/src/test/resources/predefinedPermissions/role_permissions_default_role_combined.xml
+++ b/src/test/resources/predefinedPermissions/role_permissions_default_role_combined.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://netgrif.github.io/petriflow/petriflow.schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
 	<id>permissions_test_default_6</id>
 	<initials>PTD</initials>
 	<title>Permissions test default 6</title>

--- a/src/test/resources/predefinedPermissions/role_permissions_default_role_custom.xml
+++ b/src/test/resources/predefinedPermissions/role_permissions_default_role_custom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://netgrif.github.io/petriflow/petriflow.schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
 	<id>permissions_test_default_4</id>
 	<initials>PTD</initials>
 	<title>Permissions test default 4</title>

--- a/src/test/resources/predefinedPermissions/role_permissions_default_role_defined.xml
+++ b/src/test/resources/predefinedPermissions/role_permissions_default_role_defined.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://netgrif.github.io/petriflow/petriflow.schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
 	<id>permissions_test_default_2</id>
 	<initials>PTD</initials>
 	<title>Permissions test default 2</title>

--- a/src/test/resources/predefinedPermissions/role_permissions_default_role_disabled.xml
+++ b/src/test/resources/predefinedPermissions/role_permissions_default_role_disabled.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://netgrif.github.io/petriflow/petriflow.schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
 	<id>permissions_test_default_10</id>
 	<initials>PTD</initials>
 	<title>Permissions test default 10</title>

--- a/src/test/resources/predefinedPermissions/role_permissions_default_role_missing.xml
+++ b/src/test/resources/predefinedPermissions/role_permissions_default_role_missing.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://netgrif.github.io/petriflow/petriflow.schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
 	<id>permissions_test_default_7</id>
 	<initials>PTD</initials>
 	<title>Permissions test default 7</title>

--- a/src/test/resources/predefinedPermissions/role_permissions_default_role_negative.xml
+++ b/src/test/resources/predefinedPermissions/role_permissions_default_role_negative.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://netgrif.github.io/petriflow/petriflow.schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
 	<id>permissions_test_default_5</id>
 	<initials>PTD</initials>
 	<title>Permissions test default 5</title>

--- a/src/test/resources/predefinedPermissions/role_permissions_default_role_reserved.xml
+++ b/src/test/resources/predefinedPermissions/role_permissions_default_role_reserved.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://netgrif.github.io/petriflow/petriflow.schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
 	<id>permissions_test_default_8</id>
 	<initials>PTD</initials>
 	<title>Permissions test default 8</title>

--- a/src/test/resources/predefinedPermissions/role_permissions_default_role_shadowed.xml
+++ b/src/test/resources/predefinedPermissions/role_permissions_default_role_shadowed.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://netgrif.github.io/petriflow/petriflow.schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
 	<id>permissions_test_default_3</id>
 	<initials>PTD</initials>
 	<title>Permissions test default 3</title>

--- a/src/test/resources/predefinedPermissions/role_permissions_default_role_shadowed_userref.xml
+++ b/src/test/resources/predefinedPermissions/role_permissions_default_role_shadowed_userref.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://netgrif.github.io/petriflow/petriflow.schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
 	<id>permissions_test_default_9</id>
 	<initials>PTD</initials>
 	<title>Permissions test default 9</title>

--- a/src/test/resources/predefinedPermissions/role_permissions_default_role_shadowed_usersref.xml
+++ b/src/test/resources/predefinedPermissions/role_permissions_default_role_shadowed_usersref.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://netgrif.github.io/petriflow/petriflow.schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
 	<id>permissions_test_default_11</id>
 	<initials>PTD</initials>
 	<title>Permissions test default 11</title>

--- a/src/test/resources/priloha.xml
+++ b/src/test/resources/priloha.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <document xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
-          xsi:noNamespaceSchemaLocation='https://modeler.netgrif.com/petriflow_schema.xsd'>
+          xsi:noNamespaceSchemaLocation='https://petriflow.com/petriflow.schema.xsd'>
     <id>priloha</id>
     <initials>IPR</initials>
     <version>1.0.0</version>

--- a/src/test/resources/process_delete_test.xml
+++ b/src/test/resources/process_delete_test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="https://modeler.netgrif.com/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>processDeleteTest</id>
     <initials>PDT</initials>
     <title>Process Delete Test</title>

--- a/src/test/resources/remoteFileField.xml
+++ b/src/test/resources/remoteFileField.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>remote_file_field_net</id>
     <initials>TST</initials>
     <title>Test</title>

--- a/src/test/resources/remoteFileListField.xml
+++ b/src/test/resources/remoteFileListField.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>remote_file_field_net</id>
     <initials>TST</initials>
     <title>Test</title>

--- a/src/test/resources/removeRole_test.xml
+++ b/src/test/resources/removeRole_test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="https://modeler.netgrif.com/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>test</id>
     <initials>TST</initials>
     <title>Test</title>

--- a/src/test/resources/role_cancel_test.xml
+++ b/src/test/resources/role_cancel_test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>test</id>
     <initials>TST</initials>
     <title>Test</title>

--- a/src/test/resources/rolref_view.xml
+++ b/src/test/resources/rolref_view.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>test</id>
     <initials>TST</initials>
     <title>Test</title>

--- a/src/test/resources/rule_engine_test.xml
+++ b/src/test/resources/rule_engine_test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="https://modeler.netgrif.com/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>rule_engine_test</id>
     <version>1.0.0</version>
     <initials>RLN</initials>

--- a/src/test/resources/simple_taskref.xml
+++ b/src/test/resources/simple_taskref.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="https://netgrif.github.io/petriflow/petriflow.schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>simple_taskref</id>
     <initials>STR</initials>
     <title>simple taskref</title>

--- a/src/test/resources/taskRefLayoutTest.xml
+++ b/src/test/resources/taskRefLayoutTest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="https://modeler.netgrif.com/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>taskRefLayoutTest</id>
     <version>1.0.0</version>
     <initials>NEW</initials>

--- a/src/test/resources/taskRefLayoutTest2.xml
+++ b/src/test/resources/taskRefLayoutTest2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="https://modeler.netgrif.com/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>taskRefLayoutTest2</id>
     <version>1.0.0</version>
     <initials>NEW</initials>

--- a/src/test/resources/taskRefLayoutTest3.xml
+++ b/src/test/resources/taskRefLayoutTest3.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="https://modeler.netgrif.com/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>taskRefLayoutTest3</id>
     <version>1.0.0</version>
     <initials>NEW</initials>

--- a/src/test/resources/taskRefLayoutTest4.xml
+++ b/src/test/resources/taskRefLayoutTest4.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="https://modeler.netgrif.com/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>taskRefLayoutTest3</id>
     <version>1.0.0</version>
     <initials>NEW</initials>

--- a/src/test/resources/taskRef_propagation_test_child.xml
+++ b/src/test/resources/taskRef_propagation_test_child.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>child</id>
     <version>1.0.0</version>
     <initials>CHL</initials>

--- a/src/test/resources/taskRef_propagation_test_parent.xml
+++ b/src/test/resources/taskRef_propagation_test_parent.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>parent</id>
     <version>1.0.0</version>
     <initials>PAR</initials>

--- a/src/test/resources/task_authentication_service_test.xml
+++ b/src/test/resources/task_authentication_service_test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>1</id>
     <initials>TST</initials>
     <title>TaskAuthenticationService test</title>

--- a/src/test/resources/task_authorization_service_test.xml
+++ b/src/test/resources/task_authorization_service_test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>wst</id>
     <initials>WST</initials>
     <title>WorkflowAuthorizationService test</title>

--- a/src/test/resources/task_authorization_service_test_with_userRefs.xml
+++ b/src/test/resources/task_authorization_service_test_with_userRefs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>wst_usersRef</id>
     <initials>WSU</initials>
     <title>WorkflowAuthorizationService test</title>

--- a/src/test/resources/task_cancel_net.xml
+++ b/src/test/resources/task_cancel_net.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="https://modeler.netgrif.com/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>test</id>
     <initials>TST</initials>
     <title>Test</title>

--- a/src/test/resources/task_events.xml
+++ b/src/test/resources/task_events.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>test</id>
     <initials>TST</initials>
     <title>Test</title>

--- a/src/test/resources/task_reindex_test.xml
+++ b/src/test/resources/task_reindex_test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="https://modeler.netgrif.com/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>task_reindex_test</id>
     <initials>TST</initials>
     <title>task_reindex_test</title>

--- a/src/test/resources/taskref_demo.xml
+++ b/src/test/resources/taskref_demo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="https://modeler.netgrif.com/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>taskref_demo</id>
     <version>1.0.0</version>
     <initials>TRD</initials>

--- a/src/test/resources/taskref_init.xml
+++ b/src/test/resources/taskref_init.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="https://modeler.netgrif.com/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>taskref_init_test</id>
     <initials>TIT</initials>
     <title>Task ref init test net</title>

--- a/src/test/resources/test_autocomplete_dynamic.xml
+++ b/src/test/resources/test_autocomplete_dynamic.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="petriflow_schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>test_autocomplete_dynamic</id>
     <title>Autocomplete Dynamic Net</title>
     <initials>ADN</initials>

--- a/src/test/resources/test_icon_enum.xml
+++ b/src/test/resources/test_icon_enum.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>test_icon_enum</id>
     <title>Icon Enum Net</title>
     <initials>IEN</initials>

--- a/src/test/resources/test_inter_data_actions_dynamic.xml
+++ b/src/test/resources/test_inter_data_actions_dynamic.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>test</id>
     <initials>TST</initials>
     <title>Test</title>

--- a/src/test/resources/test_inter_data_actions_static.xml
+++ b/src/test/resources/test_inter_data_actions_static.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>test_inter_data_actions_static.xml</id>
     <initials>TST</initials>
     <title>Test</title>

--- a/src/test/resources/this_kw_test.xml
+++ b/src/test/resources/this_kw_test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>this_kw_test</id>
     <initials>TKW</initials>
     <title>This keyword test net</title>

--- a/src/test/resources/user_list.xml
+++ b/src/test/resources/user_list.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>user_list</id>
     <title>User list</title>
     <initials>ULT</initials>

--- a/src/test/resources/userrefs_test.xml
+++ b/src/test/resources/userrefs_test.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="petriNets/petriflow_schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>testing_model</id>
     <initials>TSM</initials>
     <title>Testing Model</title>

--- a/src/test/resources/variable_arc_test.xml
+++ b/src/test/resources/variable_arc_test.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://modeler.netgrif.com/petriflow_schema.xsd">
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>variable_arc_test.xml</id>
     <initials>TST</initials>
     <title>Test</title>

--- a/src/test/resources/view_permission_test.xml
+++ b/src/test/resources/view_permission_test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>vpt</id>
     <initials>VPT</initials>
     <title>ViewPermissionTest test</title>

--- a/src/test/resources/view_permission_with_userRefs_test.xml
+++ b/src/test/resources/view_permission_with_userRefs_test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>vpt_userRefs</id>
     <initials>VPT</initials>
     <title>ViewPermissionTest test</title>

--- a/src/test/resources/workflow_authorization_service_test.xml
+++ b/src/test/resources/workflow_authorization_service_test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>wst</id>
     <initials>WST</initials>
     <title>WorkflowAuthorizationService test</title>

--- a/src/test/resources/workflow_authorization_service_test_with_userRefs.xml
+++ b/src/test/resources/workflow_authorization_service_test_with_userRefs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../main/resources/petriNets/petriflow_schema.xsd">
+          xsi:noNamespaceSchemaLocation="https://petriflow.com/petriflow.schema.xsd">
     <id>wst_usersRef</id>
     <initials>WSU</initials>
     <title>WorkflowAuthorizationService test</title>


### PR DESCRIPTION
# Description

Remove petriflow schema from project and reference the schema from the official site of [Petriflow](https://petriflow.com)

Implements [NAE-1584]

## Dependencies

No new dependencies were introduced.

### Third party dependencies

No new dependencies were introduced.

### Blocking Pull requests

There are no dependencies on other PR.

## How Has Been This Tested?

This was tested manually generating new schema classed using Maven.

### Test Configuration

Netgrif Backend PR Config
| Name                | Tested on |
|---------------------| --------- |
| OS                  |   macOS Monterey 12.2.1        |
| Runtime             |  Java 11        |
| Dependency Manager  |  Maven 3.8.4         |
| Framework version   |  Spring Boot 2.6.2        |
| Run parameters      |           |
| Other configuration |           |


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My changes have been checked, personally or remotely, with @machacjozef 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes:
    - [ ] Lint test
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] I have checked my contribution with code analysis tools:
    - [ ] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_application-engine)
    - [ ] [Snyk](https://app.snyk.io/org/netgrif/project/ea82b3b8-658d-41f5-89a7-76cd600da01f)
- [x] I have made corresponding changes to the documentation:
    - [x] Developer documentation
    - [x] User Guides
    - [x] Migration Guides
