### PR TITLE
[NAE-1599] Task-reffed fields are not placed in correct position

### DIFF
--- a/src/main/java/com/netgrif/application/engine/workflow/service/DataService.java
+++ b/src/main/java/com/netgrif/application/engine/workflow/service/DataService.java
@@ -17,6 +17,7 @@ import com.netgrif.application.engine.petrinet.domain.*;
 import com.netgrif.application.engine.petrinet.domain.dataset.*;
 import com.netgrif.application.engine.petrinet.domain.dataset.logic.ChangedField;
 import com.netgrif.application.engine.petrinet.domain.dataset.logic.FieldBehavior;
+import com.netgrif.application.engine.petrinet.domain.dataset.logic.FieldLayout;
 import com.netgrif.application.engine.petrinet.domain.dataset.logic.action.FieldActionsRunner;
 import com.netgrif.application.engine.petrinet.domain.events.DataEvent;
 import com.netgrif.application.engine.petrinet.domain.events.DataEventType;
@@ -310,7 +311,14 @@ public class DataService implements IDataService {
 
     private void resolveTaskRefOrderOnGrid(DataGroup dataGroup, Map<String, Field> dataFieldMap) {
         if (dataGroup.getLayout() != null && Objects.equals(dataGroup.getLayout().getType(), "grid")) {
-            dataGroup.setData(dataGroup.getData().stream().map(dataFieldMap::get).sorted(Comparator.comparingInt(a -> a.getLayout().getY())).map(Field::getStringId).collect(Collectors.toCollection(LinkedHashSet::new)));
+            List<Field> dataFieldList = dataGroup.getData().stream().map(dataFieldMap::get).collect(Collectors.toList());
+            dataFieldList.forEach(field -> {
+                if (field.getLayout() == null) {
+                    field.setLayout(new FieldLayout());
+                    field.getLayout().setY(dataGroup.getData().size() - 1);
+                }
+            });
+            dataGroup.setData(dataFieldList.stream().sorted(Comparator.comparingInt(a -> a.getLayout().getY())).map(Field::getStringId).collect(Collectors.toCollection(LinkedHashSet::new)));
         }
     }
 

--- a/src/main/java/com/netgrif/application/engine/workflow/service/DataService.java
+++ b/src/main/java/com/netgrif/application/engine/workflow/service/DataService.java
@@ -17,7 +17,6 @@ import com.netgrif.application.engine.petrinet.domain.*;
 import com.netgrif.application.engine.petrinet.domain.dataset.*;
 import com.netgrif.application.engine.petrinet.domain.dataset.logic.ChangedField;
 import com.netgrif.application.engine.petrinet.domain.dataset.logic.FieldBehavior;
-import com.netgrif.application.engine.petrinet.domain.dataset.logic.FieldLayout;
 import com.netgrif.application.engine.petrinet.domain.dataset.logic.action.FieldActionsRunner;
 import com.netgrif.application.engine.petrinet.domain.events.DataEvent;
 import com.netgrif.application.engine.petrinet.domain.events.DataEventType;

--- a/src/main/java/com/netgrif/application/engine/workflow/service/DataService.java
+++ b/src/main/java/com/netgrif/application/engine/workflow/service/DataService.java
@@ -311,14 +311,7 @@ public class DataService implements IDataService {
 
     private void resolveTaskRefOrderOnGrid(DataGroup dataGroup, Map<String, Field> dataFieldMap) {
         if (dataGroup.getLayout() != null && Objects.equals(dataGroup.getLayout().getType(), "grid")) {
-            List<Field> dataFieldList = dataGroup.getData().stream().map(dataFieldMap::get).collect(Collectors.toList());
-            dataFieldList.forEach(field -> {
-                if (field.getLayout() == null) {
-                    field.setLayout(new FieldLayout());
-                    field.getLayout().setY(dataGroup.getData().size() - 1);
-                }
-            });
-            dataGroup.setData(dataFieldList.stream().sorted(Comparator.comparingInt(a -> a.getLayout().getY())).map(Field::getStringId).collect(Collectors.toCollection(LinkedHashSet::new)));
+            dataGroup.setData(dataGroup.getData().stream().map(dataFieldMap::get).sorted(Comparator.comparingInt(a -> a.getLayout().getY())).map(Field::getStringId).collect(Collectors.toCollection(LinkedHashSet::new)));
         }
     }
 

--- a/src/main/resources/petriNets/engine-processes/filter.xml
+++ b/src/main/resources/petriNets/engine-processes/filter.xml
@@ -640,6 +640,15 @@
                         change i18nName value { new com.netgrif.application.engine.petrinet.domain.I18nString(name.value) }
                     </action>
                 </logic>
+                <layout>
+                    <x>0</x>
+                    <y>4</y>
+                    <rows>1</rows>
+                    <cols>4</cols>
+                    <offset>0</offset>
+                    <template>material</template>
+                    <appearance>outline</appearance>
+                </layout>
             </dataRef>
         </dataGroup>
         <dataGroup>


### PR DESCRIPTION
# Description

Order of data groups created from task reference fields was not correct on grid layout. It was given from the order that is defined in Petri net, but if there is a grid layout, task ref field can have specified Y positions.

Fixes [NAE-1599]

## Dependencies

No new dependencies were introduced.

### Third party dependencies

No new dependencies were introduced.

### Blocking Pull requests

There are no dependencies on other PR.

## How Has Been This Tested?

This was tested manually importing agreement.xml petri net and there is a unit test implemented for it.

- testTaskRefOrderOnGridLayout() [DataServiceTest.java](https://github.com/netgrif/application-engine/blob/release/6.0.4/src/test/groovy/com/netgrif/application/engine/workflow/DataServiceTest.groovy)

### Test Configuration

Netgrif Backend PR Config
| Name                | Tested on |
|---------------------| --------- |
| OS                  |   macOS Monterey 12.2.1        |
| Runtime             |  Java 11        |
| Dependency Manager  |  Maven 3.8.4         |
| Framework version   |  Spring Boot 2.6.2        |
| Run parameters      |           |
| Other configuration |           |

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes have been checked, personally or remotely, with @petrovicLubos  @minop 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes:
    - [x] Lint test
    - [x] Unit tests
    - [x] Integration tests
- [x] I have checked my contribution with code analysis tools:
    - [x] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_application-engine)
    - [x] [Snyk](https://app.snyk.io/org/netgrif/project/ea82b3b8-658d-41f5-89a7-76cd600da01f)
- [x] I have made corresponding changes to the documentation:
    - [x] Developer documentation
    - [x] User Guides
    - [x] Migration Guides


[NAE-1599]: https://netgrif.atlassian.net/browse/NAE-1599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ