### PR TITLE
[NAE-1440] setData on button without value

### DIFF
--- a/src/main/java/com/netgrif/application/engine/workflow/service/DataService.java
+++ b/src/main/java/com/netgrif/application/engine/workflow/service/DataService.java
@@ -770,6 +770,17 @@ public class DataService implements IDataService {
                 }
                 value = parseListStringValues(node);
                 break;
+            case "button":
+                if (node.get("value") == null) {
+                    if (dataField.getValue() == null) {
+                        value = 1;
+                        break;
+                    }
+                    value = Integer.parseInt(dataField.getValue().toString()) + 1;
+                } else {
+                    value = node.get("value").asInt();
+                }
+                break;
             default:
                 if (node.get("value") == null || node.get("value").isNull()) {
                     value = null;

--- a/src/test/groovy/com/netgrif/application/engine/workflow/SetDataOnButtonTest.groovy
+++ b/src/test/groovy/com/netgrif/application/engine/workflow/SetDataOnButtonTest.groovy
@@ -1,0 +1,125 @@
+package com.netgrif.application.engine.workflow
+
+import com.netgrif.application.engine.TestHelper
+import com.netgrif.application.engine.auth.service.interfaces.IUserService
+import com.netgrif.application.engine.petrinet.domain.PetriNet
+import com.netgrif.application.engine.petrinet.domain.VersionType
+import com.netgrif.application.engine.petrinet.service.interfaces.IPetriNetService
+import com.netgrif.application.engine.startup.ImportHelper
+import com.netgrif.application.engine.workflow.domain.Case
+import com.netgrif.application.engine.workflow.domain.QTask
+import com.netgrif.application.engine.workflow.domain.Task
+import com.netgrif.application.engine.workflow.service.interfaces.IDataService
+import com.netgrif.application.engine.workflow.service.interfaces.ITaskService
+import com.netgrif.application.engine.workflow.service.interfaces.IWorkflowService
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+@ExtendWith(SpringExtension.class)
+@ActiveProfiles(["test"])
+@SpringBootTest
+class SetDataOnButtonTest {
+
+    @Autowired
+    private ITaskService taskService
+
+    @Autowired
+    private IWorkflowService workflowService
+
+    @Autowired
+    private IDataService dataService
+
+    @Autowired
+    private ImportHelper helper
+
+    @Autowired
+    private IPetriNetService petriNetService
+
+    @Autowired
+    private IUserService userService
+
+    @Autowired
+    private TestHelper testHelper
+
+    String CHILD_CASE_FIELD_ID = "child_case_id"
+    String TEXT_0_FIELD_ID = "text_0"
+    String TEXT_1_FIELD_ID = "text_1"
+    String TEXT_2_FIELD_ID = "text_2"
+    String BUTTON_0_FIELD_ID = "button_0"
+    String BUTTON_1_FIELD_ID = "button_1"
+    String BUTTON_2_FIELD_ID = "button_2"
+    String OUTPUT_TEXT_0 = "Clicked 0!"
+    String OUTPUT_TEXT_1 = "Clicked 1!"
+    String OUTPUT_TEXT_2 = "Clicked 2!"
+    String PARENT_CASE = "Set Data On Button Parent"
+    String CHILD_CASE = "Set Data On Button Child"
+    String TEST_TRANSITION = "t1"
+    String RESOURCE_PATH = "src/test/resources/button_set_data_test.xml"
+
+    PetriNet net = null
+
+    @BeforeEach
+    void initNet() {
+        testHelper.truncateDbs()
+        net = petriNetService.importPetriNet(new FileInputStream(RESOURCE_PATH), VersionType.MAJOR, userService.loggedOrSystem.transformToLoggedUser()).getNet()
+        assert net != null
+    }
+
+    @Test
+    void setDataFromTestCase() {
+        Case parentCase = helper.createCase(PARENT_CASE, net)
+        Case childCase = helper.createCase(CHILD_CASE, net)
+
+        parentCase.dataSet[CHILD_CASE_FIELD_ID].value = childCase.getStringId()
+        assert parentCase.dataSet[CHILD_CASE_FIELD_ID].value == childCase.getStringId()
+        workflowService.save(parentCase)
+
+        Task parentTask = taskService.searchOne(QTask.task.caseTitle.eq(PARENT_CASE) & QTask.task.transitionId.eq(TEST_TRANSITION))
+        assert parentTask != null
+
+        taskService.assignTask(parentTask.getStringId())
+        taskService.finishTask(parentTask.getStringId())
+
+        childCase = workflowService.findOne(childCase.getStringId())
+
+        assert childCase.dataSet[TEXT_0_FIELD_ID].value.toString() == OUTPUT_TEXT_0
+        assert childCase.dataSet[TEXT_1_FIELD_ID].value.toString() == OUTPUT_TEXT_1
+        assert childCase.dataSet[TEXT_2_FIELD_ID].value.toString() == OUTPUT_TEXT_2
+    }
+
+    @Test
+    void setData() {
+        Case testCase = helper.createCase(PARENT_CASE, net)
+
+        Task testCaseTask = taskService.searchOne(QTask.task.caseTitle.eq(PARENT_CASE) & QTask.task.transitionId.eq(TEST_TRANSITION))
+        assert testCaseTask != null
+
+        dataService.setData(testCaseTask.stringId, ImportHelper.populateDataset([
+                "button_0": [
+                        "value": "42",
+                        "type" : "button"
+                ],
+                "button_1": [
+                        "value": 42,
+                        "type" : "button"
+                ],
+                "button_2": [
+                        "type" : "button"
+                ]
+        ]))
+
+        testCase = workflowService.findOne(testCase.getStringId())
+
+        assert testCase.dataSet[BUTTON_0_FIELD_ID].value == 42
+        assert testCase.dataSet[BUTTON_1_FIELD_ID].value == 42
+        assert testCase.dataSet[BUTTON_2_FIELD_ID].value == 1
+        assert testCase.dataSet[TEXT_0_FIELD_ID].value.toString() == OUTPUT_TEXT_0
+        assert testCase.dataSet[TEXT_1_FIELD_ID].value.toString() == OUTPUT_TEXT_1
+        assert testCase.dataSet[TEXT_2_FIELD_ID].value.toString() == OUTPUT_TEXT_2
+    }
+}

--- a/src/test/resources/button_set_data_test.xml
+++ b/src/test/resources/button_set_data_test.xml
@@ -1,0 +1,167 @@
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://netgrif.github.io/petriflow/petriflow.schema.xsd">
+	<id>button_set_data</id>
+	<initials>SDB</initials>
+	<title>Set Data Button v3</title>
+	<icon>device_hub</icon>
+	<defaultRole>true</defaultRole>
+	<anonymousRole>true</anonymousRole>
+	<transitionRole>false</transitionRole>
+	<data type="text">
+		<id>child_case_id</id>
+		<title/>
+		<event type="get">
+			<id>ref</id>
+			<actions phase="pre">
+				<action>
+					child_case_id: f.child_case_id;
+
+					if (!child_case_id.value) {
+						def childCase = createCase("button_set_data", "Child button set data case")
+						change child_case_id value { childCase.stringId }
+					}
+				</action>
+			</actions>
+		</event>
+	</data>
+	<data type="button">
+		<id>button_0</id>
+		<title/>
+		<placeholder>Set Data</placeholder>
+		<action trigger="set">
+			txt: f.text_0;
+
+			change txt value { "Clicked 0!" }
+		</action>
+	</data>
+	<data type="button">
+		<id>button_1</id>
+		<title/>
+		<placeholder>Set Data</placeholder>
+		<action trigger="set">
+			txt: f.text_1;
+
+			change txt value { "Clicked 1!" }
+		</action>
+	</data>
+	<data type="button">
+		<id>button_2</id>
+		<title/>
+		<placeholder>Set Data</placeholder>
+		<action trigger="set">
+			txt: f.text_2;
+
+			change txt value { "Clicked 2!" }
+		</action>
+	</data>
+	<data type="text">
+		<id>text_0</id>
+		<title>Result 0</title>
+	</data>
+	<data type="text">
+		<id>text_1</id>
+		<title>Result 1</title>
+	</data>
+	<data type="text">
+		<id>text_2</id>
+		<title>Result 2</title>
+	</data>
+	<transition>
+		<id>t1</id>
+		<x>300</x>
+		<y>140</y>
+		<label>task</label>
+		<dataGroup>
+			<id>t1</id>
+			<cols>4</cols>
+			<layout>legacy</layout>
+			<dataRef>
+				<id>child_case_id</id>
+				<logic>
+					<behavior>hidden</behavior>
+				</logic>
+			</dataRef>
+			<dataRef>
+				<id>button_0</id>
+				<logic>
+					<behavior>editable</behavior>
+				</logic>
+				<layout>
+					<template>material</template>
+					<appearance>outline</appearance>
+				</layout>
+			</dataRef>
+			<dataRef>
+				<id>text_0</id>
+				<logic>
+					<behavior>visible</behavior>
+				</logic>
+				<layout>
+					<template>material</template>
+					<appearance>outline</appearance>
+				</layout>
+			</dataRef>
+			<dataRef>
+				<id>button_1</id>
+				<logic>
+					<behavior>editable</behavior>
+				</logic>
+				<layout>
+					<template>material</template>
+					<appearance>outline</appearance>
+				</layout>
+			</dataRef>
+			<dataRef>
+				<id>text_1</id>
+				<logic>
+					<behavior>visible</behavior>
+				</logic>
+				<layout>
+					<template>material</template>
+					<appearance>outline</appearance>
+				</layout>
+			</dataRef>
+			<dataRef>
+				<id>button_2</id>
+				<logic>
+					<behavior>editable</behavior>
+				</logic>
+				<layout>
+					<template>material</template>
+					<appearance>outline</appearance>
+				</layout>
+			</dataRef>
+			<dataRef>
+				<id>text_2</id>
+				<logic>
+					<behavior>visible</behavior>
+				</logic>
+				<layout>
+					<template>material</template>
+					<appearance>outline</appearance>
+				</layout>
+			</dataRef>
+		</dataGroup>
+		<event type="finish">
+			<id>ref</id>
+			<actions phase="pre">
+				<action>
+					child_case_id: f.child_case_id;
+
+					def childCase = workflowService.findOne(child_case_id.value as String)
+
+					setData("t1", childCase, [
+						"button_0": [
+							"type" : "button"
+						],
+						"button_1": [
+							"type" : "button"
+						],
+						"button_2": [
+							"type" : "button"
+						],
+					])
+				</action>
+			</actions>
+		</event>
+	</transition>
+</document>


### PR DESCRIPTION
# Description

 Updated parseFieldsValues() with button case
 Added test Petri net
 Added test of functionality

Implements [NAE-1440]

## Dependencies


### Third party dependencies

No new dependencies were introduced

### Blocking Pull requests

There are no dependencies on other PR

## How Has Been This Tested?

Tested on test Petri net (button_set_data_test.xml) and created test of mentioned Petri net and test using dataService

- [Test Petri net](https://github.com/netgrif/application-engine/blob/NAE-1440/src/test/resources/button_set_data_test.xml)
- [Functionality test](https://github.com/netgrif/application-engine/blob/NAE-1440/src/test/groovy/com/netgrif/application/engine/workflow/SetDataOnButtonTest.groovy)

### Test Configuration

| Name                | Tested on |
|---------------------| --------- |
| OS                  |   Windows 11        |
| Runtime             |  Java 11        |
| Dependency Manager  |  Maven 3.8.4         |
| Framework version   |  Spring Boot 2.6.2        |
| Run parameters      |           |
| Other configuration |           |

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes have been checked, personally or remotely, with @timbez 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes:
    - [x] Lint test
    - [x] Unit tests
    - [x] Integration tests
- [x] I have checked my contribution with code analysis tools:
    - [x] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_application-engine)
    - [x] [Snyk](https://app.snyk.io/org/netgrif/project/ea82b3b8-658d-41f5-89a7-76cd600da01f)
- [x] I have made corresponding changes to the documentation:
    - [x] Developer documentation
    - [x] User Guides
    - [x] Migration Guides


[NAE-1440]: https://netgrif.atlassian.net/browse/NAE-1440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ