### PR TITLE
[NAE-1621] Required data group layout tag if layout type is “grid”

### DIFF
--- a/src/main/java/com/netgrif/application/engine/importer/service/Importer.java
+++ b/src/main/java/com/netgrif/application/engine/importer/service/Importer.java
@@ -715,8 +715,12 @@ public class Importer {
         dataGroup.setStretch(importDataGroup.isStretch());
         importDataGroup.getDataRef().forEach(dataRef -> dataGroup.addData(getField(dataRef.getId()).getStringId()));
         transition.addDataGroup(dataGroup);
+        DataGroupLayout dataGroupLayout = dataGroup.getLayout();
 
         for (DataRef dataRef : importDataGroup.getDataRef()) {
+            if (dataGroupLayout != null && dataGroupLayout.getType().equals(LayoutType.GRID.value()) && dataRef.getLayout() == null) {
+                throw new IllegalArgumentException("Data ref [" + dataRef.getId() + "] of data group [" + dataGroup.getStringId() + "] in transition [" + transition.getStringId() + "] doesn't have a layout.");
+            }
             addDataLogic(transition, dataRef);
             addDataLayout(transition, dataRef);
             addDataComponent(transition, dataRef);

--- a/src/test/groovy/com/netgrif/application/engine/petrinet/domain/ImporterTest.groovy
+++ b/src/test/groovy/com/netgrif/application/engine/petrinet/domain/ImporterTest.groovy
@@ -361,4 +361,18 @@ class ImporterTest {
 
     }
 
+    @Test
+    void importWithInvalidDataRefLayoutTest() {
+        boolean exceptionThrown = false
+
+        try {
+            petriNetService.importPetriNet(new FileInputStream("src/test/resources/invalid_data_ref_layout.xml"), VersionType.MAJOR, superCreator.getLoggedSuper()).getNet()
+        } catch (IllegalArgumentException e) {
+            exceptionThrown = true
+            assert e.message.contains("doesn't have a layout")
+        }
+
+        assert exceptionThrown
+    }
+
 }

--- a/src/test/resources/invalid_data_ref_layout.xml
+++ b/src/test/resources/invalid_data_ref_layout.xml
@@ -1,0 +1,50 @@
+<document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://netgrif.github.io/petriflow/petriflow.schema.xsd">
+	<id>invalid_data_ref_layout</id>
+	<initials>IDR</initials>
+	<title>Invalid data ref in grid layout</title>
+	<icon>device_hub</icon>
+	<defaultRole>true</defaultRole>
+	<anonymousRole>true</anonymousRole>
+	<transitionRole>false</transitionRole>
+	<data type="text">
+		<id>text_0</id>
+		<title>Text field</title>
+		<init>Text field with layout</init>
+	</data>
+	<data type="text">
+		<id>text_1</id>
+		<title>Text field</title>
+		<init>Text field without layout</init>
+	</data>
+	<transition>
+		<id>t1</id>
+		<x>500</x>
+		<y>180</y>
+		<label/>
+		<dataGroup>
+			<id>t1</id>
+			<cols>4</cols>
+			<layout>grid</layout>
+			<dataRef>
+				<id>text_0</id>
+				<logic>
+					<behavior>visible</behavior>
+				</logic>
+				<layout>
+					<x>0</x>
+					<y>0</y>
+					<rows>1</rows>
+					<cols>2</cols>
+					<template>material</template>
+					<appearance>outline</appearance>
+				</layout>
+			</dataRef>
+			<dataRef>
+				<id>text_1</id>
+				<logic>
+					<behavior>visible</behavior>
+				</logic>
+			</dataRef>
+		</dataGroup>
+	</transition>
+</document>


### PR DESCRIPTION
# Description

Added validation on data field layout if data group grid layout is present
Added test Petri net & test of functionality

Fixes [NAE-1621]

## Dependencies

None

### Third party dependencies

No new dependencies were introduced

### Blocking Pull requests

There are no dependencies on other PR

## How Has Been This Tested?

Tested on newly added Petri net (invalid_data_ref_layout.xml) manually in application and in written test

- [invalid_data_ref_layout.xml](https://github.com/netgrif/application-engine/blob/NAE-1621/src/test/resources/invalid_data_ref_layout.xml)
- importWithInvalidDataRefLayoutTest() [ImporterTest.groovy](https://github.com/netgrif/application-engine/blob/NAE-1621/src/test/groovy/com/netgrif/application/engine/petrinet/domain/ImporterTest.groovy)

### Test Configuration

| Name                | Tested on |
|---------------------| --------- |
| OS                  |   Windows 11        |
| Runtime             |  Java 11        |
| Dependency Manager  |  Maven 3.8.4         |
| Framework version   |  Spring Boot 2.6.2        |
| Run parameters      |           |
| Other configuration |           |

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes have been checked, personally or remotely, with @timbez @machacjozef 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes:
    - [ ] Lint test
    - [x] Unit tests
    - [ ] Integration tests
- [ ] I have checked my contribution with code analysis tools:
    - [ ] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_application-engine)
    - [ ] [Snyk](https://app.snyk.io/org/netgrif/project/ea82b3b8-658d-41f5-89a7-76cd600da01f)
- [x] I have made corresponding changes to the documentation:
    - [x] Developer documentation
    - [x] User Guides
    - [x] Migration Guides
