### PR TITLE
[NAE-1636] resolveTaskRefOrderOnGrid with forbidden dataField

### DIFF
--- a/src/main/java/com/netgrif/application/engine/workflow/service/DataService.java
+++ b/src/main/java/com/netgrif/application/engine/workflow/service/DataService.java
@@ -310,7 +310,14 @@ public class DataService implements IDataService {
 
     private void resolveTaskRefOrderOnGrid(DataGroup dataGroup, Map<String, Field> dataFieldMap) {
         if (dataGroup.getLayout() != null && Objects.equals(dataGroup.getLayout().getType(), "grid")) {
-            dataGroup.setData(dataGroup.getData().stream().map(dataFieldMap::get).sorted(Comparator.comparingInt(a -> a.getLayout().getY())).map(Field::getStringId).collect(Collectors.toCollection(LinkedHashSet::new)));
+            dataGroup.setData(
+                    dataGroup.getData().stream()
+                            .filter(dataFieldMap::containsKey)
+                            .map(dataFieldMap::get)
+                            .sorted(Comparator.comparingInt(a -> a.getLayout().getY()))
+                            .map(Field::getStringId)
+                            .collect(Collectors.toCollection(LinkedHashSet::new))
+            );
         }
     }
 


### PR DESCRIPTION
# Description

Fixes [NAE-1636]
- filter forbidden fields in dataGroup when resolving order on grid

## Dependencies

No new dependencies were introduced

### Third party dependencies

No new dependencies were introduced

### Blocking Pull requests

There are no dependencies on other PR

## How Has Been This Tested?

Manually tested in example app

### Test Configuration

| Name                | Tested on |
|---------------------| --------- |
| OS                  |   Linux Mint 20.3        |
| Runtime             |  Java 11.0.15        |
| Dependency Manager  |  Maven 3.8.1         |
| Framework version   |  Spring Boot 2.6.7        |
| Run parameters      |           |
| Other configuration |           |

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes have been checked, personally or remotely, with @renczesstefan 
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have resolved all conflicts with the target branch of the PR
- [X] I have updated and synced my code with the target branch
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing tests pass locally with my changes:
    - [X] Lint test
    - [X] Unit tests
    - [X] Integration tests
- [ ] I have checked my contribution with code analysis tools:
    - [ ] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_application-engine)
    - [x] [Snyk](https://app.snyk.io/org/netgrif/project/ea82b3b8-658d-41f5-89a7-76cd600da01f)
- [X] I have made corresponding changes to the documentation:
    - [X] Developer documentation
    - [X] User Guides
    - [X] Migration Guides


[NAE-1636]: https://netgrif.atlassian.net/browse/NAE-1636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ