### PR TITLE
[NAE-1639] Non-Latin1 characters cannot be used in passwords

### DIFF
--- a/src/main/java/com/netgrif/application/engine/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/netgrif/application/engine/configuration/SecurityConfiguration.java
@@ -7,6 +7,7 @@ import com.netgrif.application.engine.auth.service.interfaces.IAfterRegistration
 import com.netgrif.application.engine.auth.service.interfaces.IAuthorityService;
 import com.netgrif.application.engine.auth.service.interfaces.IUserService;
 import com.netgrif.application.engine.configuration.properties.SecurityConfigProperties;
+import com.netgrif.application.engine.configuration.security.CredentialsConverterFilter;
 import com.netgrif.application.engine.configuration.security.PublicAuthenticationFilter;
 import com.netgrif.application.engine.configuration.security.RestAuthenticationEntryPoint;
 import com.netgrif.application.engine.configuration.security.SecurityContextFilter;
@@ -117,6 +118,7 @@ public class SecurityConfiguration extends AbstractSecurityConfiguration {
                 .cors()
                 .and()
             .addFilterBefore(createPublicAuthenticationFilter(), BasicAuthenticationFilter.class)
+            .addFilterBefore(new CredentialsConverterFilter(), PublicAuthenticationFilter.class)
             .addFilterAfter(createSecurityContextFilter(), BasicAuthenticationFilter.class)
             .authorizeRequests()
                 .antMatchers(getPatterns()).permitAll()

--- a/src/main/java/com/netgrif/application/engine/configuration/security/CredentialsConverterFilter.java
+++ b/src/main/java/com/netgrif/application/engine/configuration/security/CredentialsConverterFilter.java
@@ -1,0 +1,63 @@
+package com.netgrif.application.engine.configuration.security;
+
+import com.netgrif.application.engine.configuration.security.wrapper.HeaderRequestWrapper;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.net.URLDecoder;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+public class CredentialsConverterFilter extends OncePerRequestFilter {
+
+    @Getter
+    @Setter
+    private Charset credentialsCharset = StandardCharsets.UTF_8;
+
+    private static final String AUTHENTICATION_SCHEME_BASIC = "Basic";
+
+    public CredentialsConverterFilter() {}
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        HeaderRequestWrapper wrappedRequest = new HeaderRequestWrapper(request);
+        convert(wrappedRequest);
+        filterChain.doFilter(wrappedRequest, response);
+    }
+
+    private void convert(HeaderRequestWrapper request) {
+        String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (header == null) {
+            return;
+        }
+        if (!StringUtils.startsWithIgnoreCase(header, AUTHENTICATION_SCHEME_BASIC)) {
+            return ;
+        }
+        if (header.equalsIgnoreCase(AUTHENTICATION_SCHEME_BASIC)) {
+            throw new BadCredentialsException("Empty basic authentication token");
+        }
+
+        header = header.trim();
+        byte[] base64Token = header.substring(6).getBytes(StandardCharsets.UTF_8);
+        byte[] decoded = Base64.getDecoder().decode(base64Token);
+        String token = URLDecoder.decode(new String(decoded, this.credentialsCharset), this.credentialsCharset);
+
+        int delim = token.indexOf(":");
+        if (delim == -1) {
+            throw new BadCredentialsException("Invalid basic authentication token");
+        }
+
+        String urlDecodedHeader = AUTHENTICATION_SCHEME_BASIC + " " + new String(Base64.getEncoder().encode(token.getBytes()));
+        request.addHeader(HttpHeaders.AUTHORIZATION, urlDecodedHeader);
+    }
+}

--- a/src/main/java/com/netgrif/application/engine/configuration/security/wrapper/HeaderRequestWrapper.java
+++ b/src/main/java/com/netgrif/application/engine/configuration/security/wrapper/HeaderRequestWrapper.java
@@ -1,0 +1,50 @@
+package com.netgrif.application.engine.configuration.security.wrapper;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import java.util.*;
+
+public class HeaderRequestWrapper extends HttpServletRequestWrapper {
+
+    public HeaderRequestWrapper(HttpServletRequest request) {
+        super(request);
+    }
+
+    private Map<String, String> headerMap = new HashMap<>();
+
+    public void addHeader(String name, String value) {
+        headerMap.put(name, value);
+    }
+
+    public void removeHeader(String name) {
+        headerMap.remove(name);
+    }
+
+    @Override
+    public String getHeader(String name) {
+        String headerValue = super.getHeader(name);
+        if (headerMap.containsKey(name)) {
+            headerValue = headerMap.get(name);
+        }
+        return headerValue;
+    }
+
+    @Override
+    public Enumeration<String> getHeaderNames() {
+        List<String> names = Collections.list(super.getHeaderNames());
+        for (String name : headerMap.keySet()) {
+            names.add(name);
+        }
+        return Collections.enumeration(names);
+    }
+
+    @Override
+    public Enumeration<String> getHeaders(String name) {
+        List<String> values = Collections.list(super.getHeaders(name));
+        if (headerMap.containsKey(name)) {
+            values.add(headerMap.get(name));
+        }
+        return Collections.enumeration(values);
+    }
+
+}


### PR DESCRIPTION
# Description

Characters such as č, š cannot be used in passwords because the following error is thrown:
login.component.html:2 ERROR DOMException: Failed to execute 'btoa' on 'Window': The string to be encoded contains characters outside of the Latin1 range.

Fixes [NAE-1639]

## Dependencies

No new dependencies were introduced.

### Third party dependencies

No new dependencies were introduced.

### Blocking Pull requests

There are no dependencies on other PR.

## How Has Been This Tested?

This was tested manually and using unit tests.

### Test Configuration

| Name                | Tested on |
|---------------------| --------- |
| OS                  |   macOS Monterey 12.2.1        |
| Runtime             |  Java 11        |
| Dependency Manager  |  Maven 3.8.4         |
| Framework version   |  Spring Boot 2.6.2        |
| Run parameters      |           |
| Other configuration |           |

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My changes have been checked, personally or remotely, with @timbez @minop 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes:
    - [ ] Lint test
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] I have checked my contribution with code analysis tools:
    - [ ] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_application-engine)
    - [ ] [Snyk](https://app.snyk.io/org/netgrif/project/ea82b3b8-658d-41f5-89a7-76cd600da01f)
- [x] I have made corresponding changes to the documentation:
    - [x] Developer documentation
    - [x] User Guides
    - [x] Migration Guides


[NAE-1639]: https://netgrif.atlassian.net/browse/NAE-1639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ