### PR TITLE
[NAE-1694] ProcessRoleService.findByImportId doesn't return list of process roles

### DIFF
--- a/src/main/groovy/com/netgrif/application/engine/startup/AnonymousRoleRunner.groovy
+++ b/src/main/groovy/com/netgrif/application/engine/startup/AnonymousRoleRunner.groovy
@@ -20,7 +20,7 @@ class AnonymousRoleRunner extends AbstractOrderedCommandLineRunner {
     void run(String... strings) throws Exception {
         log.info("Creating anonymous process role")
 
-        def role = repository.findByName_DefaultValue(ProcessRole.ANONYMOUS_ROLE)
+        def role = repository.findAllByName_DefaultValue(ProcessRole.ANONYMOUS_ROLE)
         if (role) {
             log.info("Anonymous role already exists")
             return

--- a/src/main/groovy/com/netgrif/application/engine/startup/AnonymousRoleRunner.groovy
+++ b/src/main/groovy/com/netgrif/application/engine/startup/AnonymousRoleRunner.groovy
@@ -20,8 +20,8 @@ class AnonymousRoleRunner extends AbstractOrderedCommandLineRunner {
     void run(String... strings) throws Exception {
         log.info("Creating anonymous process role")
 
-        def role = repository.findAllByName_DefaultValue(ProcessRole.ANONYMOUS_ROLE)
-        if (role) {
+        def role = repository.findAllByImportId(ProcessRole.ANONYMOUS_ROLE)
+        if (role && !role.isEmpty()) {
             log.info("Anonymous role already exists")
             return
         }

--- a/src/main/groovy/com/netgrif/application/engine/startup/DefaultRoleRunner.groovy
+++ b/src/main/groovy/com/netgrif/application/engine/startup/DefaultRoleRunner.groovy
@@ -31,7 +31,7 @@ class DefaultRoleRunner extends AbstractOrderedCommandLineRunner {
         }
 
         ProcessRole defaultRole = new ProcessRole(
-                importId: "0",
+                importId: ProcessRole.DEFAULT_ROLE,
                 name: new I18nString(ProcessRole.DEFAULT_ROLE),
                 description: "Default system process role",
                 events: new LinkedHashMap<EventType, Event>()

--- a/src/main/groovy/com/netgrif/application/engine/startup/DefaultRoleRunner.groovy
+++ b/src/main/groovy/com/netgrif/application/engine/startup/DefaultRoleRunner.groovy
@@ -24,7 +24,7 @@ class DefaultRoleRunner extends AbstractOrderedCommandLineRunner {
     void run(String... strings) throws Exception {
         log.info("Creating default process role")
 
-        def role = repository.findByName_DefaultValue(ProcessRole.DEFAULT_ROLE)
+        def role = repository.findAllByName_DefaultValue(ProcessRole.DEFAULT_ROLE)
         if (role) {
             log.info("Default role already exists")
             return

--- a/src/main/groovy/com/netgrif/application/engine/startup/ImportHelper.groovy
+++ b/src/main/groovy/com/netgrif/application/engine/startup/ImportHelper.groovy
@@ -11,7 +11,7 @@ import com.netgrif.application.engine.petrinet.domain.VersionType
 import com.netgrif.application.engine.petrinet.domain.dataset.Field
 import com.netgrif.application.engine.petrinet.domain.repositories.PetriNetRepository
 import com.netgrif.application.engine.petrinet.domain.roles.ProcessRole
-import com.netgrif.application.engine.petrinet.domain.roles.ProcessRoleRepository
+import com.netgrif.application.engine.petrinet.service.ProcessRoleService
 import com.netgrif.application.engine.petrinet.service.interfaces.IPetriNetService
 import com.netgrif.application.engine.workflow.domain.Case
 import com.netgrif.application.engine.workflow.domain.Filter
@@ -85,7 +85,7 @@ class ImportHelper {
     private INextGroupService groupService
 
     @Autowired
-    private ProcessRoleRepository processRoleRepository
+    private ProcessRoleService processRoleService
 
     private final ClassLoader loader = ImportHelper.getClassLoader()
 
@@ -155,7 +155,7 @@ class ImportHelper {
     }
 
     Map<String, ProcessRole> getProcessRoles(PetriNet net) {
-        List<ProcessRole> roles = processRoleRepository.findAllByNetId(net.stringId)
+        List<ProcessRole> roles = processRoleService.findAll(net.stringId)
         Map<String, ProcessRole> map = [:]
         net.roles.values().each { netRole ->
             map[netRole.name.getDefaultValue()] = roles.find { it.roleId == netRole.stringId }

--- a/src/main/java/com/netgrif/application/engine/auth/service/AbstractUserService.java
+++ b/src/main/java/com/netgrif/application/engine/auth/service/AbstractUserService.java
@@ -80,7 +80,14 @@ public abstract class AbstractUserService implements IUserService {
         return save(user);
     }
 
+    /**
+     * @deprecated use {@link AbstractUserService#removeRole(IUser, ProcessRole)} instead
+     * @param user
+     * @param roleStringId
+     * @return
+     */
     @Override
+    @Deprecated(since = "6.2.0")
     public IUser removeRole(IUser user, String roleStringId) {
         return removeRole(user, processRoleService.findByImportId(roleStringId));
     }

--- a/src/main/java/com/netgrif/application/engine/importer/service/Importer.java
+++ b/src/main/java/com/netgrif/application/engine/importer/service/Importer.java
@@ -28,10 +28,10 @@ import com.netgrif.application.engine.petrinet.domain.policies.AssignPolicy;
 import com.netgrif.application.engine.petrinet.domain.policies.DataFocusPolicy;
 import com.netgrif.application.engine.petrinet.domain.policies.FinishPolicy;
 import com.netgrif.application.engine.petrinet.domain.roles.ProcessRole;
-import com.netgrif.application.engine.petrinet.domain.roles.ProcessRoleRepository;
 import com.netgrif.application.engine.petrinet.domain.throwable.MissingPetriNetMetaDataException;
 import com.netgrif.application.engine.petrinet.service.ArcFactory;
 import com.netgrif.application.engine.petrinet.service.interfaces.IPetriNetService;
+import com.netgrif.application.engine.petrinet.service.interfaces.IProcessRoleService;
 import com.netgrif.application.engine.workflow.domain.FileStorageConfiguration;
 import com.netgrif.application.engine.workflow.domain.triggers.Trigger;
 import com.netgrif.application.engine.workflow.service.interfaces.IFieldActionsCacheService;
@@ -88,7 +88,7 @@ public class Importer {
     protected IPetriNetService service;
 
     @Autowired
-    protected ProcessRoleRepository roleRepository;
+    protected IProcessRoleService processRoleService;
 
     @Autowired
     protected ArcFactory arcFactory;
@@ -151,8 +151,8 @@ public class Importer {
         this.places = new HashMap<>();
         this.fields = new HashMap<>();
         this.transactions = new HashMap<>();
-        this.defaultRole = roleRepository.findByName_DefaultValue(ProcessRole.DEFAULT_ROLE);
-        this.anonymousRole = roleRepository.findByName_DefaultValue(ProcessRole.ANONYMOUS_ROLE);
+        this.defaultRole = processRoleService.defaultRole();
+        this.anonymousRole = processRoleService.anonymousRole();
         this.i18n = new HashMap<>();
         this.actions = new HashMap<>();
         this.actionRefs = new HashMap<>();

--- a/src/main/java/com/netgrif/application/engine/ldap/service/LdapGroupRefService.java
+++ b/src/main/java/com/netgrif/application/engine/ldap/service/LdapGroupRefService.java
@@ -9,9 +9,8 @@ import com.netgrif.application.engine.ldap.domain.LdapGroupRef;
 import com.netgrif.application.engine.ldap.domain.repository.LdapGroupRoleRepository;
 import com.netgrif.application.engine.ldap.service.interfaces.ILdapGroupRefService;
 import com.netgrif.application.engine.petrinet.domain.roles.ProcessRole;
-import com.netgrif.application.engine.petrinet.domain.roles.ProcessRoleRepository;
+import com.netgrif.application.engine.petrinet.service.interfaces.IProcessRoleService;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.ldap.core.ContextMapper;
 import org.springframework.ldap.core.DirContextAdapter;
@@ -32,17 +31,21 @@ import static org.springframework.ldap.query.LdapQueryBuilder.query;
 @ConditionalOnExpression("${nae.ldap.enabled:false}")
 public class LdapGroupRefService implements ILdapGroupRefService {
 
-    @Autowired
-    private LdapConfiguration ldapConfiguration;
+    private final LdapConfiguration ldapConfiguration;
 
-    @Autowired
-    private LdapGroupRoleRepository ldapGroupRoleRepository;
+    private final LdapGroupRoleRepository ldapGroupRoleRepository;
 
-    @Autowired
-    private ProcessRoleRepository processRoleRepository;
+    private final IProcessRoleService processRoleService;
 
-    @Autowired
-    private NaeLdapProperties ldapProperties;
+    private final NaeLdapProperties ldapProperties;
+
+    public LdapGroupRefService(LdapConfiguration ldapConfiguration, LdapGroupRoleRepository ldapGroupRoleRepository,
+                               IProcessRoleService processRoleService, NaeLdapProperties ldapProperties) {
+        this.ldapConfiguration = ldapConfiguration;
+        this.ldapGroupRoleRepository = ldapGroupRoleRepository;
+        this.processRoleService = processRoleService;
+        this.ldapProperties = ldapProperties;
+    }
 
     @Override
     public List<LdapGroupRef> findAllGroups() {
@@ -82,7 +85,7 @@ public class LdapGroupRefService implements ILdapGroupRefService {
 
     @Override
     public void setRoleToLdapGroup(String groupDn, Set<String> requestedRolesIds, LoggedUser loggedUser) {
-        Set<ProcessRole> requestedRoles = processRoleRepository.findAllBy_idIn(requestedRolesIds);
+        Set<ProcessRole> requestedRoles = processRoleService.findByIds(requestedRolesIds);
         if (requestedRoles.isEmpty() && !requestedRolesIds.isEmpty())
             throw new IllegalArgumentException("No process roles found.");
         if (requestedRoles.size() != requestedRolesIds.size())

--- a/src/main/java/com/netgrif/application/engine/petrinet/domain/roles/ProcessRoleRepository.java
+++ b/src/main/java/com/netgrif/application/engine/petrinet/domain/roles/ProcessRoleRepository.java
@@ -15,9 +15,9 @@ public interface ProcessRoleRepository extends MongoRepository<ProcessRole, Stri
 
     Set<ProcessRole> findAllByImportIdIn(Set<String> importIds);
 
-    Set<ProcessRole> findByName_DefaultValue(String name);
+    Set<ProcessRole> findAllByName_DefaultValue(String name);
 
-    Set<ProcessRole> findByImportId(String importId);
+    Set<ProcessRole> findAllByImportId(String importId);
 
     void deleteAllBy_idIn(Collection<ObjectId> ids);
 }

--- a/src/main/java/com/netgrif/application/engine/petrinet/domain/roles/ProcessRoleRepository.java
+++ b/src/main/java/com/netgrif/application/engine/petrinet/domain/roles/ProcessRoleRepository.java
@@ -11,19 +11,13 @@ import java.util.Set;
 @Repository
 public interface ProcessRoleRepository extends MongoRepository<ProcessRole, String>, QuerydslPredicateExecutor<ProcessRole> {
 
-    Set<ProcessRole> findAllById(Iterable<String> strings);
-
     Set<ProcessRole> findAllByNetId(String netId);
-
-    Set<ProcessRole> findAllBy_idIn(Set<String> ids);
-
-    ProcessRole findBy_id(String id);
 
     Set<ProcessRole> findAllByImportIdIn(Set<String> importIds);
 
-    ProcessRole findByName_DefaultValue(String name);
+    Set<ProcessRole> findByName_DefaultValue(String name);
 
-    ProcessRole findByImportId(String importId);
+    Set<ProcessRole> findByImportId(String importId);
 
     void deleteAllBy_idIn(Collection<ObjectId> ids);
 }

--- a/src/main/java/com/netgrif/application/engine/petrinet/service/ProcessRoleService.java
+++ b/src/main/java/com/netgrif/application/engine/petrinet/service/ProcessRoleService.java
@@ -231,7 +231,7 @@ public class ProcessRoleService implements IProcessRoleService {
     @Override
     public ProcessRole defaultRole() {
         if (defaultRole == null) {
-            Set<ProcessRole> roles = processRoleRepository.findByName_DefaultValue(ProcessRole.DEFAULT_ROLE);
+            Set<ProcessRole> roles = processRoleRepository.findAllByName_DefaultValue(ProcessRole.DEFAULT_ROLE);
             if (roles.isEmpty())
                 throw new IllegalStateException("No default process role has been found!");
             if (roles.size() > 1)
@@ -244,7 +244,7 @@ public class ProcessRoleService implements IProcessRoleService {
     @Override
     public ProcessRole anonymousRole() {
         if (anonymousRole == null) {
-            Set<ProcessRole> roles = processRoleRepository.findByName_DefaultValue(ProcessRole.ANONYMOUS_ROLE);
+            Set<ProcessRole> roles = processRoleRepository.findAllByName_DefaultValue(ProcessRole.ANONYMOUS_ROLE);
             if (roles.isEmpty())
                 throw new IllegalStateException("No anonymous process role has been found!");
             if (roles.size() > 1)
@@ -262,17 +262,17 @@ public class ProcessRoleService implements IProcessRoleService {
     @Deprecated(forRemoval = true, since = "6.2.0")
     @Override
     public ProcessRole findByImportId(String importId) {
-        return processRoleRepository.findByImportId(importId).stream().findFirst().orElse(null);
+        return processRoleRepository.findAllByImportId(importId).stream().findFirst().orElse(null);
     }
 
     @Override
     public Set<ProcessRole> findAllByImportId(String importId) {
-        return processRoleRepository.findByImportId(importId);
+        return processRoleRepository.findAllByImportId(importId);
     }
 
     @Override
     public Set<ProcessRole> findAllByDefaultName(String name) {
-        return processRoleRepository.findByName_DefaultValue(name);
+        return processRoleRepository.findAllByName_DefaultValue(name);
     }
 
     @Override

--- a/src/main/java/com/netgrif/application/engine/petrinet/service/ProcessRoleService.java
+++ b/src/main/java/com/netgrif/application/engine/petrinet/service/ProcessRoleService.java
@@ -244,7 +244,7 @@ public class ProcessRoleService implements IProcessRoleService {
     @Override
     public ProcessRole anonymousRole() {
         if (anonymousRole == null) {
-            Set<ProcessRole> roles = processRoleRepository.findAllByName_DefaultValue(ProcessRole.ANONYMOUS_ROLE);
+            Set<ProcessRole> roles = processRoleRepository.findAllByImportId(ProcessRole.ANONYMOUS_ROLE);
             if (roles.isEmpty())
                 throw new IllegalStateException("No anonymous process role has been found!");
             if (roles.size() > 1)

--- a/src/main/java/com/netgrif/application/engine/petrinet/service/ProcessRoleService.java
+++ b/src/main/java/com/netgrif/application/engine/petrinet/service/ProcessRoleService.java
@@ -2,7 +2,6 @@ package com.netgrif.application.engine.petrinet.service;
 
 import com.netgrif.application.engine.auth.domain.IUser;
 import com.netgrif.application.engine.auth.domain.LoggedUser;
-import com.netgrif.application.engine.auth.service.UserDetailsServiceImpl;
 import com.netgrif.application.engine.auth.service.interfaces.IUserService;
 import com.netgrif.application.engine.event.events.user.UserRoleChangeEvent;
 import com.netgrif.application.engine.importer.model.EventPhaseType;
@@ -21,45 +20,42 @@ import com.netgrif.application.engine.security.service.ISecurityContextService;
 import org.bson.types.ObjectId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 @Service
 public class ProcessRoleService implements IProcessRoleService {
 
     private static final Logger log = LoggerFactory.getLogger(ProcessRoleService.class);
 
-    @Autowired
-    private IUserService userService;
-
-    @Autowired
-    private ProcessRoleRepository processRoleRepository;
-
-    @Autowired
-    private PetriNetRepository netRepository;
-
-    @Autowired
-    private UserDetailsServiceImpl userDetailsService;
-
-    @Autowired
-    private ApplicationEventPublisher publisher;
-
-    @Autowired
-    private RoleActionsRunner roleActionsRunner;
-
-    @Autowired
-    private IPetriNetService petriNetService;
-
-    @Autowired
-    private ISecurityContextService securityContextService;
+    private final IUserService userService;
+    private final ProcessRoleRepository processRoleRepository;
+    private final PetriNetRepository netRepository;
+    private final ApplicationEventPublisher publisher;
+    private final RoleActionsRunner roleActionsRunner;
+    private final IPetriNetService petriNetService;
+    private final ISecurityContextService securityContextService;
 
     private ProcessRole defaultRole;
-
     private ProcessRole anonymousRole;
+
+    public ProcessRoleService(IUserService userService, ProcessRoleRepository processRoleRepository,
+                              PetriNetRepository netRepository,
+                              ApplicationEventPublisher publisher, RoleActionsRunner roleActionsRunner,
+                              @Lazy IPetriNetService petriNetService, ISecurityContextService securityContextService) {
+        this.userService = userService;
+        this.processRoleRepository = processRoleRepository;
+        this.netRepository = netRepository;
+        this.publisher = publisher;
+        this.roleActionsRunner = roleActionsRunner;
+        this.petriNetService = petriNetService;
+        this.securityContextService = securityContextService;
+    }
 
     @Override
     public List<ProcessRole> saveAll(Iterable<ProcessRole> entities) {
@@ -68,14 +64,14 @@ public class ProcessRoleService implements IProcessRoleService {
 
     @Override
     public Set<ProcessRole> findByIds(Set<String> ids) {
-        return processRoleRepository.findAllBy_idIn(ids);
+        return StreamSupport.stream(processRoleRepository.findAllById(ids).spliterator(), false).collect(Collectors.toSet());
     }
 
     @Override
     public void assignRolesToUser(String userId, Set<String> requestedRolesIds, LoggedUser loggedUser) {
         IUser user = userService.resolveById(userId, true);
-        Set<ProcessRole> requestedRoles = processRoleRepository.findAllBy_idIn(requestedRolesIds);
-        if (requestedRoles.isEmpty() && requestedRolesIds.size() != 0)
+        Set<ProcessRole> requestedRoles = this.findByIds(requestedRolesIds);
+        if (requestedRoles.isEmpty() && !requestedRolesIds.isEmpty())
             throw new IllegalArgumentException("No process roles found.");
         if (requestedRoles.size() != requestedRolesIds.size())
             throw new IllegalArgumentException("Not all process roles were found!");
@@ -95,8 +91,8 @@ public class ProcessRoleService implements IProcessRoleService {
         Set<String> rolesNewToUserIds = mapUserRolesToIds(rolesNewToUser);
         Set<String> rolesRemovedFromUserIds = mapUserRolesToIds(rolesRemovedFromUser);
 
-        Set<ProcessRole> newRoles = processRoleRepository.findAllBy_idIn(rolesNewToUserIds);
-        Set<ProcessRole> removedRoles = processRoleRepository.findAllBy_idIn(rolesRemovedFromUserIds);
+        Set<ProcessRole> newRoles = this.findByIds(rolesNewToUserIds);
+        Set<ProcessRole> removedRoles = this.findByIds(rolesRemovedFromUserIds);
 
         runAllPreActions(newRoles, removedRoles, user, petriNet);
         requestedRoles = updateRequestedRoles(user, rolesNewToUser, rolesRemovedFromUser);
@@ -139,7 +135,7 @@ public class ProcessRoleService implements IProcessRoleService {
 
     private void replaceUserRolesAndPublishEvent(Set<String> requestedRolesIds, IUser user, Set<ProcessRole> requestedRoles) {
         removeOldAndAssignNewRolesToUser(user, requestedRoles);
-        publisher.publishEvent(new UserRoleChangeEvent(user, processRoleRepository.findAllBy_idIn(requestedRolesIds)));
+        publisher.publishEvent(new UserRoleChangeEvent(user, this.findByIds(requestedRolesIds)));
     }
 
     private Set<ProcessRole> getRolesNewToUser(Set<ProcessRole> userOldRoles, Set<ProcessRole> newRequestedRoles) {
@@ -223,7 +219,7 @@ public class ProcessRoleService implements IProcessRoleService {
     @Override
     public List<ProcessRole> findAll(String netId) {
         Optional<PetriNet> netOptional = netRepository.findById(netId);
-        if (!netOptional.isPresent())
+        if (netOptional.isEmpty())
             throw new IllegalArgumentException("Could not find model with id [" + netId + "]");
         return findAll(netOptional.get());
     }
@@ -234,26 +230,54 @@ public class ProcessRoleService implements IProcessRoleService {
 
     @Override
     public ProcessRole defaultRole() {
-        if (defaultRole == null)
-            defaultRole = processRoleRepository.findByName_DefaultValue(ProcessRole.DEFAULT_ROLE);
+        if (defaultRole == null) {
+            Set<ProcessRole> roles = processRoleRepository.findByName_DefaultValue(ProcessRole.DEFAULT_ROLE);
+            if (roles.isEmpty())
+                throw new IllegalStateException("No default process role has been found!");
+            if (roles.size() > 1)
+                throw new IllegalStateException("More than 1 default process role exists!");
+            defaultRole = roles.stream().findFirst().orElse(null);
+        }
         return defaultRole;
     }
 
     @Override
     public ProcessRole anonymousRole() {
-        if (anonymousRole == null)
-            anonymousRole = processRoleRepository.findByName_DefaultValue(ProcessRole.ANONYMOUS_ROLE);
+        if (anonymousRole == null) {
+            Set<ProcessRole> roles = processRoleRepository.findByName_DefaultValue(ProcessRole.ANONYMOUS_ROLE);
+            if (roles.isEmpty())
+                throw new IllegalStateException("No anonymous process role has been found!");
+            if (roles.size() > 1)
+                throw new IllegalStateException("More than 1 anonymous process role exists!");
+            anonymousRole = roles.stream().findFirst().orElse(null);
+        }
         return anonymousRole;
     }
 
+    /**
+     * @param importId id from a process of a role
+     * @return a process role object
+     * @deprecated use {@link ProcessRoleService#findAllByImportId(String)} instead
+     */
+    @Deprecated(forRemoval = true, since = "6.2.0")
     @Override
     public ProcessRole findByImportId(String importId) {
+        return processRoleRepository.findByImportId(importId).stream().findFirst().orElse(null);
+    }
+
+    @Override
+    public Set<ProcessRole> findAllByImportId(String importId) {
         return processRoleRepository.findByImportId(importId);
     }
 
     @Override
+    public Set<ProcessRole> findAllByDefaultName(String name) {
+        return processRoleRepository.findByName_DefaultValue(name);
+    }
+
+    @Override
     public ProcessRole findById(String id) {
-        return processRoleRepository.findBy_id(id);
+        return processRoleRepository.findById(id).orElse(null);
     }
 
     @Override

--- a/src/main/java/com/netgrif/application/engine/petrinet/service/interfaces/IProcessRoleService.java
+++ b/src/main/java/com/netgrif/application/engine/petrinet/service/interfaces/IProcessRoleService.java
@@ -11,6 +11,10 @@ public interface IProcessRoleService {
 
     List<ProcessRole> saveAll(Iterable<ProcessRole> entities);
 
+    Set<ProcessRole> findAllByImportId(String importId);
+
+    Set<ProcessRole> findAllByDefaultName(String name);
+
     ProcessRole findById(String id);
 
     Set<ProcessRole> findByIds(Set<String> ids);

--- a/src/test/groovy/com/netgrif/application/engine/action/AssignActionTest.groovy
+++ b/src/test/groovy/com/netgrif/application/engine/action/AssignActionTest.groovy
@@ -142,8 +142,8 @@ class AssignActionTest {
         User updatedUser = userRepository.findByEmail(USER_EMAIL)
         Set<ProcessRole> roles = updatedUser.getProcessRoles()
 
-        String adminMainId = processRoleRepository.findByName_DefaultValue("admin_main").stringId
-        String adminSecondaryId = processRoleRepository.findByName_DefaultValue("admin_secondary").stringId
+        String adminMainId = processRoleRepository.findByName_DefaultValue("admin_main")?.first()?.stringId
+        String adminSecondaryId = processRoleRepository.findByName_DefaultValue("admin_secondary")?.first()?.stringId
 
         assert roles.find { it.stringId == adminMainId }
         assert roles.find { it.stringId == adminSecondaryId }

--- a/src/test/groovy/com/netgrif/application/engine/action/AssignActionTest.groovy
+++ b/src/test/groovy/com/netgrif/application/engine/action/AssignActionTest.groovy
@@ -142,8 +142,8 @@ class AssignActionTest {
         User updatedUser = userRepository.findByEmail(USER_EMAIL)
         Set<ProcessRole> roles = updatedUser.getProcessRoles()
 
-        String adminMainId = processRoleRepository.findByName_DefaultValue("admin_main")?.first()?.stringId
-        String adminSecondaryId = processRoleRepository.findByName_DefaultValue("admin_secondary")?.first()?.stringId
+        String adminMainId = processRoleRepository.findAllByName_DefaultValue("admin_main")?.first()?.stringId
+        String adminSecondaryId = processRoleRepository.findAllByName_DefaultValue("admin_secondary")?.first()?.stringId
 
         assert roles.find { it.stringId == adminMainId }
         assert roles.find { it.stringId == adminSecondaryId }

--- a/src/test/groovy/com/netgrif/application/engine/action/RemoveActionTest.groovy
+++ b/src/test/groovy/com/netgrif/application/engine/action/RemoveActionTest.groovy
@@ -133,7 +133,7 @@ class RemoveActionTest {
         User updatedUser = userRepository.findByEmail(USER_EMAIL)
         Set<ProcessRole> roles = updatedUser.getProcessRoles()
 
-        String managerRoleId = processRoleRepository.findByName_DefaultValue("manager").stringId
+        String managerRoleId = processRoleRepository.findAllByName_DefaultValue("manager").stringId
 
         assert roles.find { it.getStringId() == adminRoleId }
         assert roles.find { it.getStringId() == managerRoleId }

--- a/src/test/groovy/com/netgrif/application/engine/action/RemoveActionTest.groovy
+++ b/src/test/groovy/com/netgrif/application/engine/action/RemoveActionTest.groovy
@@ -133,7 +133,7 @@ class RemoveActionTest {
         User updatedUser = userRepository.findByEmail(USER_EMAIL)
         Set<ProcessRole> roles = updatedUser.getProcessRoles()
 
-        String managerRoleId = processRoleRepository.findAllByName_DefaultValue("manager").stringId
+        String managerRoleId = processRoleRepository.findAllByName_DefaultValue("manager")?.first()?.stringId
 
         assert roles.find { it.getStringId() == adminRoleId }
         assert roles.find { it.getStringId() == managerRoleId }
@@ -155,6 +155,6 @@ class RemoveActionTest {
         roles = updatedUser.getProcessRoles()
 
         Assert.assertNull(roles.find { it.stringId == adminRoleId })
-        Assert.assert(roles.find { it.stringId == managerRoleId })
+        Assert.assertNotNull(roles.find { it.stringId == managerRoleId })
     }
 }

--- a/src/test/groovy/com/netgrif/application/engine/auth/TaskAuthorizationServiceTest.groovy
+++ b/src/test/groovy/com/netgrif/application/engine/auth/TaskAuthorizationServiceTest.groovy
@@ -10,7 +10,6 @@ import com.netgrif.application.engine.importer.service.Importer
 import com.netgrif.application.engine.petrinet.domain.PetriNet
 import com.netgrif.application.engine.petrinet.domain.VersionType
 import com.netgrif.application.engine.petrinet.domain.roles.ProcessRole
-import com.netgrif.application.engine.petrinet.domain.roles.ProcessRoleRepository
 import com.netgrif.application.engine.petrinet.service.interfaces.IPetriNetService
 import com.netgrif.application.engine.startup.ImportHelper
 import com.netgrif.application.engine.startup.SuperCreator
@@ -80,9 +79,6 @@ class TaskAuthorizationServiceTest {
 
     @Autowired
     private IPetriNetService petriNetService
-
-    @Autowired
-    private ProcessRoleRepository userProcessRoleRepository
 
     @Autowired
     private ITaskAuthorizationService taskAuthorizationService

--- a/src/test/groovy/com/netgrif/application/engine/petrinet/domain/ActionRefTest.groovy
+++ b/src/test/groovy/com/netgrif/application/engine/petrinet/domain/ActionRefTest.groovy
@@ -3,7 +3,6 @@ package com.netgrif.application.engine.petrinet.domain
 import com.netgrif.application.engine.TestHelper
 import com.netgrif.application.engine.auth.domain.repositories.UserRepository
 import com.netgrif.application.engine.petrinet.domain.repositories.PetriNetRepository
-import com.netgrif.application.engine.petrinet.domain.roles.ProcessRoleRepository
 import com.netgrif.application.engine.petrinet.service.interfaces.IPetriNetService
 import com.netgrif.application.engine.startup.SuperCreator
 import com.netgrif.application.engine.workflow.domain.repositories.CaseRepository
@@ -45,9 +44,6 @@ class ActionRefTest {
 
     @Autowired
     private UserRepository userRepository
-
-    @Autowired
-    private ProcessRoleRepository roleRepository
 
     @Autowired
     private TestHelper testHelper

--- a/src/test/groovy/com/netgrif/application/engine/petrinet/domain/EventTest.groovy
+++ b/src/test/groovy/com/netgrif/application/engine/petrinet/domain/EventTest.groovy
@@ -5,7 +5,6 @@ import com.netgrif.application.engine.auth.domain.repositories.UserRepository
 import com.netgrif.application.engine.importer.service.Importer
 import com.netgrif.application.engine.ipc.TaskApiTest
 import com.netgrif.application.engine.petrinet.domain.repositories.PetriNetRepository
-import com.netgrif.application.engine.petrinet.domain.roles.ProcessRoleRepository
 import com.netgrif.application.engine.petrinet.service.interfaces.IPetriNetService
 import com.netgrif.application.engine.startup.DefaultRoleRunner
 import com.netgrif.application.engine.startup.ImportHelper
@@ -65,9 +64,6 @@ class EventTest {
 
     @Autowired
     private UserRepository userRepository
-
-    @Autowired
-    private ProcessRoleRepository roleRepository
 
     @Autowired
     private SystemUserRunner userRunner

--- a/src/test/groovy/com/netgrif/application/engine/petrinet/domain/dataset/FieldTest.groovy
+++ b/src/test/groovy/com/netgrif/application/engine/petrinet/domain/dataset/FieldTest.groovy
@@ -5,7 +5,6 @@ import com.netgrif.application.engine.auth.domain.repositories.UserRepository
 import com.netgrif.application.engine.importer.service.Importer
 import com.netgrif.application.engine.ipc.TaskApiTest
 import com.netgrif.application.engine.petrinet.domain.PetriNet
-import com.netgrif.application.engine.petrinet.domain.roles.ProcessRoleRepository
 import com.netgrif.application.engine.startup.GroupRunner
 import com.netgrif.application.engine.startup.SuperCreator
 import com.netgrif.application.engine.startup.SystemUserRunner
@@ -35,9 +34,6 @@ class FieldTest {
 
     @Autowired
     private UserRepository userRepository
-
-    @Autowired
-    private ProcessRoleRepository roleRepository
 
     @Autowired
     private SystemUserRunner systemUserRunner

--- a/src/test/java/com/netgrif/application/engine/petrinet/service/ProcessRoleServiceTest.java
+++ b/src/test/java/com/netgrif/application/engine/petrinet/service/ProcessRoleServiceTest.java
@@ -72,6 +72,7 @@ class ProcessRoleServiceTest {
     void shouldGetDefaultRole() {
         ProcessRole role = processRoleService.defaultRole();
         assertNotNull(role);
+        assertEquals(ProcessRole.DEFAULT_ROLE, role.getImportId());
         assertEquals(ProcessRole.DEFAULT_ROLE, role.getName().getDefaultValue());
     }
 

--- a/src/test/java/com/netgrif/application/engine/petrinet/service/ProcessRoleServiceTest.java
+++ b/src/test/java/com/netgrif/application/engine/petrinet/service/ProcessRoleServiceTest.java
@@ -1,0 +1,105 @@
+package com.netgrif.application.engine.petrinet.service;
+
+import com.netgrif.application.engine.TestHelper;
+import com.netgrif.application.engine.petrinet.domain.VersionType;
+import com.netgrif.application.engine.petrinet.domain.roles.ProcessRole;
+import com.netgrif.application.engine.petrinet.domain.throwable.MissingPetriNetMetaDataException;
+import com.netgrif.application.engine.petrinet.service.interfaces.IPetriNetService;
+import com.netgrif.application.engine.petrinet.service.interfaces.IProcessRoleService;
+import com.netgrif.application.engine.startup.SuperCreator;
+import com.netgrif.application.engine.workflow.domain.eventoutcomes.petrinetoutcomes.ImportPetriNetEventOutcome;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@ActiveProfiles({"test"})
+@ExtendWith(SpringExtension.class)
+class ProcessRoleServiceTest {
+
+    private final static String ROLE_IMPORT_ID = "process_role";
+
+    @Autowired
+    private TestHelper testHelper;
+
+    @Autowired
+    private IPetriNetService petriNetService;
+
+    @Autowired
+    private IProcessRoleService processRoleService;
+
+    @Autowired
+    private SuperCreator superCreator;
+
+    @BeforeEach
+    public void before() {
+        testHelper.truncateDbs();
+    }
+
+
+    @Test
+    void shouldFindAllProcessRoles() throws IOException, MissingPetriNetMetaDataException {
+        petriNetService.importPetriNet(new FileInputStream("src/test/resources/all_data.xml"), VersionType.MAJOR, superCreator.getLoggedSuper());
+        petriNetService.importPetriNet(new FileInputStream("src/test/resources/role_all_data.xml"), VersionType.MAJOR, superCreator.getLoggedSuper());
+        List<ProcessRole> roles = processRoleService.findAll();
+        assertNotNull(roles);
+        assertFalse(roles.isEmpty());
+        assertEquals(6, roles.size());
+    }
+
+    @Test
+    void shouldFindAllProcessRolesByPetriNet() throws IOException, MissingPetriNetMetaDataException {
+        ImportPetriNetEventOutcome eventOutcome = petriNetService.importPetriNet(new FileInputStream("src/test/resources/all_data.xml"), VersionType.MAJOR, superCreator.getLoggedSuper());
+        List<ProcessRole> roles = processRoleService.findAll(eventOutcome.getNet().getStringId());
+        assertNotNull(roles);
+        assertFalse(roles.isEmpty());
+        assertEquals(1, roles.size());
+        assertEquals(ROLE_IMPORT_ID, roles.get(0).getImportId());
+    }
+
+    @Test
+    void shouldGetDefaultRole() {
+        ProcessRole role = processRoleService.defaultRole();
+        assertNotNull(role);
+        assertEquals(ProcessRole.DEFAULT_ROLE, role.getName().getDefaultValue());
+    }
+
+    @Test
+    void shouldGetAnonymousRole() {
+        ProcessRole role = processRoleService.anonymousRole();
+        assertNotNull(role);
+        assertEquals(ProcessRole.ANONYMOUS_ROLE, role.getName().getDefaultValue());
+        assertEquals(ProcessRole.ANONYMOUS_ROLE, role.getImportId());
+    }
+
+    @Test
+    void shouldFindAllProcessRolesByImportId() throws IOException, MissingPetriNetMetaDataException {
+        petriNetService.importPetriNet(new FileInputStream("src/test/resources/all_data.xml"), VersionType.MAJOR, superCreator.getLoggedSuper());
+        Set<ProcessRole> roles = processRoleService.findAllByImportId(ROLE_IMPORT_ID);
+        assertNotNull(roles);
+        assertFalse(roles.isEmpty());
+        assertEquals(1, roles.size());
+        assertEquals(ROLE_IMPORT_ID, roles.stream().findFirst().get().getImportId());
+    }
+
+    @Test
+    void shouldFindAllProcessRolesByName() throws IOException, MissingPetriNetMetaDataException {
+        petriNetService.importPetriNet(new FileInputStream("src/test/resources/all_data.xml"), VersionType.MAJOR, superCreator.getLoggedSuper());
+        Set<ProcessRole> roles = processRoleService.findAllByDefaultName("Process role");
+        assertNotNull(roles);
+        assertFalse(roles.isEmpty());
+        assertEquals(1, roles.size());
+        assertEquals(ROLE_IMPORT_ID, roles.stream().findFirst().get().getImportId());
+    }
+}

--- a/src/test/java/com/netgrif/application/engine/workflow/web/VariableArcsTest.java
+++ b/src/test/java/com/netgrif/application/engine/workflow/web/VariableArcsTest.java
@@ -99,7 +99,7 @@ public class VariableArcsTest {
         testHelper.truncateDbs();
         userRunner.run("");
         repository.deleteAll();
-        if (roleRepository.findByName_DefaultValue(ProcessRole.DEFAULT_ROLE) == null) {
+        if (roleRepository.findAllByName_DefaultValue(ProcessRole.DEFAULT_ROLE) == null) {
             try {
                 defaultRoleRunner.run();
             } catch (Exception e) {

--- a/src/test/java/com/netgrif/application/engine/workflow/web/VariableArcsTest.java
+++ b/src/test/java/com/netgrif/application/engine/workflow/web/VariableArcsTest.java
@@ -12,9 +12,9 @@ import com.netgrif.application.engine.petrinet.domain.PetriNet;
 import com.netgrif.application.engine.petrinet.domain.arcs.Arc;
 import com.netgrif.application.engine.petrinet.domain.repositories.PetriNetRepository;
 import com.netgrif.application.engine.petrinet.domain.roles.ProcessRole;
-import com.netgrif.application.engine.petrinet.domain.roles.ProcessRoleRepository;
 import com.netgrif.application.engine.petrinet.domain.throwable.TransitionNotExecutableException;
 import com.netgrif.application.engine.petrinet.service.interfaces.IPetriNetService;
+import com.netgrif.application.engine.petrinet.service.interfaces.IProcessRoleService;
 import com.netgrif.application.engine.startup.DefaultRoleRunner;
 import com.netgrif.application.engine.startup.ImportHelper;
 import com.netgrif.application.engine.startup.SuperCreator;
@@ -41,6 +41,8 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import java.io.FileInputStream;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @SpringBootTest
 @ActiveProfiles({"test"})
@@ -69,7 +71,7 @@ public class VariableArcsTest {
     private DefaultRoleRunner defaultRoleRunner;
 
     @Autowired
-    private ProcessRoleRepository roleRepository;
+    private IProcessRoleService processRoleService;
 
     @Autowired
     private ImportHelper importHelper;
@@ -99,13 +101,7 @@ public class VariableArcsTest {
         testHelper.truncateDbs();
         userRunner.run("");
         repository.deleteAll();
-        if (roleRepository.findAllByName_DefaultValue(ProcessRole.DEFAULT_ROLE) == null) {
-            try {
-                defaultRoleRunner.run();
-            } catch (Exception e) {
-                log.error("VariableArcsTest failed: ", e);
-            }
-        }
+        assertNotNull(processRoleService.defaultRole());
         testHelper.truncateDbs();
         ImportPetriNetEventOutcome outcome = service.importPetriNet(new FileInputStream(NET_PATH), "major", superCreator.getLoggedSuper());
 


### PR DESCRIPTION
# Description

Fixes old bug with method ProcessRoleService.findByImportId that returns only one process role even if for that importId several exist. 
There has been added a new method findAllByImport that returns a collection of process roles and the old one is deprecated for backwards compatibility.

Fixes [NAE-1694]

## Dependencies

### Third-party dependencies

No new dependencies were introduced

### Blocking Pull requests

There are no dependencies on other PR

## How Has Been This Tested?

Methods were tested manually and by unit tests.

- [ProcessRoleServiceTest](src/test/java/com/netgrif/application/engine/petrinet/service/ProcessRoleServiceTest.java)

### Test Configuration

Windows 11, RedHat OpenJDK 11, JUnit 5, Spring Boot tests context.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes have been checked, personally or remotely, with @machacjozef 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes:
    - [ ] Lint test
    - [x] Unit tests
    - [ ] Integration tests
- [x] I have checked my contribution with code analysis tools:
    - [x] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_application-engine)
    - [x] [Snyk](https://app.snyk.io/org/netgrif/project/ea82b3b8-658d-41f5-89a7-76cd600da01f)
- [ ] I have made corresponding changes to the documentation:
    - [ ] Developer documentation
    - [ ] User Guides
    - [ ] Migration Guides


[NAE-1694]: https://netgrif.atlassian.net/browse/NAE-1694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ