### PR TITLE
[NAE-1699] Create/upload event action is loaded only from the cache

### DIFF
--- a/src/main/java/com/netgrif/application/engine/importer/service/Importer.java
+++ b/src/main/java/com/netgrif/application/engine/importer/service/Importer.java
@@ -201,8 +201,6 @@ public class Importer {
         document.getData().forEach(this::addActionRefs);
         actionRefs.forEach(this::resolveActionRefs);
         document.getFunction().forEach(this::createFunction);
-        evaluateFunctions();
-        actions.forEach(this::evaluateActions);
         document.getRoleRef().forEach(this::resolveRoleRef);
         document.getUsersRef().forEach(this::resolveUserRef);
         document.getUserRef().forEach(this::resolveUserRef);
@@ -211,6 +209,8 @@ public class Importer {
 
         resolveProcessEvents(document.getProcessEvents());
         resolveCaseEvents(document.getCaseEvents());
+        evaluateFunctions();
+        actions.forEach(this::evaluateActions);
 
         if (document.getCaseName() != null && document.getCaseName().isDynamic()) {
             net.setDefaultCaseNameExpression(new Expression(document.getCaseName().getValue()));


### PR DESCRIPTION
# Description

If new version of any petri net has any process or case event, these functions were not reloaded in function cache.

Fixes [NAE-1699]

## Dependencies

No new dependencies were introduced.

### Third party dependencies

No new dependencies were introduced.

### Blocking Pull requests

There are no dependencies on other PR.

## How Has Been This Tested?

This was tested manually.

### Test Configuration

| Name                | Tested on |
|---------------------| --------- |
| OS                  |   macOS Monterey 12.4        |
| Runtime             |  Java 11        |
| Dependency Manager  |  Maven 3.8.4         |
| Framework version   |  Spring Boot 2.6.2        |
| Run parameters      |           |
| Other configuration |           |

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes have been checked, personally or remotely, with @petrovicLubos 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes:
    - [x] Lint test
    - [x] Unit tests
    - [x] Integration tests
- [x] I have checked my contribution with code analysis tools:
    - [x] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_application-engine)
    - [x] [Snyk](https://app.snyk.io/org/netgrif/project/ea82b3b8-658d-41f5-89a7-76cd600da01f)
- [x] I have made corresponding changes to the documentation:
    - [x] Developer documentation
    - [x] User Guides
    - [x] Migration Guides


[NAE-1699]: https://netgrif.atlassian.net/browse/NAE-1699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ