### PR TITLE
[NAE-1626] Trigger of set event for fileList value deletion is not implemented

### DIFF
--- a/src/main/java/com/netgrif/application/engine/workflow/service/DataService.java
+++ b/src/main/java/com/netgrif/application/engine/workflow/service/DataService.java
@@ -617,10 +617,11 @@ public class DataService implements IDataService {
     }
 
     @Override
-    public boolean deleteFile(String taskId, String fieldId) {
+    public SetDataEventOutcome deleteFile(String taskId, String fieldId) {
         ImmutablePair<Case, FileField> pair = getCaseAndFileField(taskId, fieldId);
         FileField field = pair.getRight();
         Case useCase = pair.getLeft();
+        Task task = taskService.findById(taskId);
 
         if (useCase.getDataSet().get(field.getStringId()).getValue() != null) {
             if (field.isRemote()) {
@@ -631,10 +632,7 @@ public class DataService implements IDataService {
             }
             useCase.getDataSet().get(field.getStringId()).setValue(null);
         }
-
-        updateDataset(useCase);
-        workflowService.save(useCase);
-        return true;
+        return new SetDataEventOutcome(useCase, task, getChangedFieldByFileFieldContainer(fieldId, task, useCase));
     }
 
     private ImmutablePair<Case, FileField> getCaseAndFileField(String taskId, String fieldId) {
@@ -647,10 +645,11 @@ public class DataService implements IDataService {
     }
 
     @Override
-    public boolean deleteFileByName(String taskId, String fieldId, String name) {
+    public SetDataEventOutcome deleteFileByName(String taskId, String fieldId, String name) {
         ImmutablePair<Case, FileListField> pair = getCaseAndFileListField(taskId, fieldId);
         FileListField field = pair.getRight();
         Case useCase = pair.getLeft();
+        Task task = taskService.findOne(taskId);
 
         Optional<FileFieldValue> fileField = field.getValue().getNamesPaths().stream().filter(namePath -> namePath.getName().equals(name)).findFirst();
 
@@ -663,10 +662,7 @@ public class DataService implements IDataService {
             }
             useCase.getDataSet().get(field.getStringId()).setValue(field.getValue());
         }
-
-        updateDataset(useCase);
-        workflowService.save(useCase);
-        return true;
+        return new SetDataEventOutcome(useCase, task, getChangedFieldByFileFieldContainer(fieldId, task, useCase));
     }
 
     private ImmutablePair<Case, FileListField> getCaseAndFileListField(String taskId, String fieldId) {

--- a/src/main/java/com/netgrif/application/engine/workflow/service/interfaces/IDataService.java
+++ b/src/main/java/com/netgrif/application/engine/workflow/service/interfaces/IDataService.java
@@ -47,9 +47,9 @@ public interface IDataService {
 
     SetDataEventOutcome saveFiles(String taskId, String fieldId, MultipartFile[] multipartFile);
 
-    boolean deleteFile(String taskId, String fieldId);
+    SetDataEventOutcome deleteFile(String taskId, String fieldId);
 
-    boolean deleteFileByName(String taskId, String fieldId, String name);
+    SetDataEventOutcome deleteFileByName(String taskId, String fieldId, String name);
 
     GetDataGroupsEventOutcome getDataGroups(String taskId, Locale locale);
 

--- a/src/main/java/com/netgrif/application/engine/workflow/web/AbstractTaskController.java
+++ b/src/main/java/com/netgrif/application/engine/workflow/web/AbstractTaskController.java
@@ -245,11 +245,12 @@ public abstract class AbstractTaskController {
                 .body(new InputStreamResource(fileFieldInputStream.getInputStream()));
     }
 
-    public MessageResource deleteFile(String taskId, String fieldId) {
-        if (dataService.deleteFile(taskId, fieldId))
-            return MessageResource.successMessage("File in field " + fieldId + " within task " + taskId + " was successfully deleted");
-        return MessageResource.errorMessage("File in field " + fieldId + " within task" + taskId + " has failed to delete");
-    }
+    public EntityModel<EventOutcomeWithMessage> deleteFile(String taskId, String fieldId) {
+        Map<String, SetDataEventOutcome> outcomes = new HashMap<>();
+        outcomes.put(taskId, dataService.deleteFile(taskId, fieldId));
+        SetDataEventOutcome mainOutcome = taskService.getMainOutcome(outcomes, taskId);
+        return EventOutcomeWithMessageResource.successMessage("Data field values have been sucessfully set",
+                LocalisedEventOutcomeFactory.from(mainOutcome, LocaleContextHolder.getLocale()));    }
 
     public EntityModel<EventOutcomeWithMessage> saveFiles(String taskId, String fieldId, MultipartFile[] multipartFiles, Map<String, String> dataBody) {
         Map<String, SetDataEventOutcome> outcomes = new HashMap<>();
@@ -275,10 +276,12 @@ public abstract class AbstractTaskController {
                 .body(new InputStreamResource(fileFieldInputStream.getInputStream()));
     }
 
-    public MessageResource deleteNamedFile(String taskId, String fieldId, String name) {
-        if (dataService.deleteFileByName(taskId, fieldId, name))
-            return MessageResource.successMessage("File with name " + name + " in field " + fieldId + " within task " + taskId + " was successfully deleted");
-        return MessageResource.errorMessage("File with name " + name + " in field " + fieldId + " within task" + taskId + " has failed to delete");
+    public EntityModel<EventOutcomeWithMessage> deleteNamedFile(String taskId, String fieldId, String name) {
+        Map<String, SetDataEventOutcome> outcomes = new HashMap<>();
+        outcomes.put(taskId, dataService.deleteFileByName(taskId, fieldId, name));
+        SetDataEventOutcome mainOutcome = taskService.getMainOutcome(outcomes, taskId);
+        return EventOutcomeWithMessageResource.successMessage("Data field values have been sucessfully set",
+                LocalisedEventOutcomeFactory.from(mainOutcome, LocaleContextHolder.getLocale()));
     }
 
     public ResponseEntity<Resource> getFilePreview(String taskId, String fieldId) throws FileNotFoundException {

--- a/src/main/java/com/netgrif/application/engine/workflow/web/PublicTaskController.java
+++ b/src/main/java/com/netgrif/application/engine/workflow/web/PublicTaskController.java
@@ -154,7 +154,7 @@ public class PublicTaskController extends AbstractTaskController {
             @ApiResponse(code = 200, message = "OK", response = MessageResource.class),
             @ApiResponse(code = 403, message = "Caller doesn't fulfill the authorisation requirements"),
     })
-    public MessageResource deleteFile(@PathVariable("id") String taskId, @PathVariable("field") String fieldId) {
+    public EntityModel<EventOutcomeWithMessage> deleteFile(@PathVariable("id") String taskId, @PathVariable("field") String fieldId) {
         return super.deleteFile(taskId, fieldId);
     }
 
@@ -192,7 +192,7 @@ public class PublicTaskController extends AbstractTaskController {
             @ApiResponse(code = 200, message = "OK", response = MessageResource.class),
             @ApiResponse(code = 403, message = "Caller doesn't fulfill the authorisation requirements"),
     })
-    public MessageResource deleteNamedFile(@PathVariable("id") String taskId, @PathVariable("field") String fieldId, @PathVariable("name") String name) {
+    public EntityModel<EventOutcomeWithMessage> deleteNamedFile(@PathVariable("id") String taskId, @PathVariable("field") String fieldId, @PathVariable("name") String name) {
         return super.deleteNamedFile(taskId, fieldId, name);
     }
 

--- a/src/main/java/com/netgrif/application/engine/workflow/web/TaskController.java
+++ b/src/main/java/com/netgrif/application/engine/workflow/web/TaskController.java
@@ -222,7 +222,7 @@ public class TaskController extends AbstractTaskController {
             @ApiResponse(code = 200, message = "OK", response = MessageResource.class),
             @ApiResponse(code = 403, message = "Caller doesn't fulfill the authorisation requirements"),
     })
-    public MessageResource deleteFile(Authentication auth, @PathVariable("id") String taskId, @PathVariable("field") String fieldId) {
+    public EntityModel<EventOutcomeWithMessage> deleteFile(Authentication auth, @PathVariable("id") String taskId, @PathVariable("field") String fieldId) {
         return super.deleteFile(taskId, fieldId);
     }
 
@@ -256,7 +256,7 @@ public class TaskController extends AbstractTaskController {
             @ApiResponse(code = 200, message = "OK", response = MessageResource.class),
             @ApiResponse(code = 403, message = "Caller doesn't fulfill the authorisation requirements"),
     })
-    public MessageResource deleteNamedFile(Authentication auth, @PathVariable("id") String taskId, @PathVariable("field") String fieldId, @PathVariable("name") String name) {
+    public EntityModel<EventOutcomeWithMessage> deleteNamedFile(Authentication auth, @PathVariable("id") String taskId, @PathVariable("field") String fieldId, @PathVariable("name") String name) {
         return super.deleteNamedFile(taskId, fieldId, name);
     }
 

--- a/src/test/groovy/com/netgrif/application/engine/workflow/TaskControllerTest.groovy
+++ b/src/test/groovy/com/netgrif/application/engine/workflow/TaskControllerTest.groovy
@@ -9,6 +9,8 @@ import com.netgrif.application.engine.auth.service.interfaces.IUserService
 import com.netgrif.application.engine.elastic.service.interfaces.IElasticTaskService
 import com.netgrif.application.engine.petrinet.domain.PetriNet
 import com.netgrif.application.engine.petrinet.domain.VersionType
+import com.netgrif.application.engine.petrinet.domain.dataset.FileFieldValue
+import com.netgrif.application.engine.petrinet.domain.dataset.FileListFieldValue
 import com.netgrif.application.engine.petrinet.domain.roles.ProcessRole
 import com.netgrif.application.engine.petrinet.service.ProcessRoleService
 import com.netgrif.application.engine.petrinet.service.interfaces.IPetriNetService
@@ -20,6 +22,9 @@ import com.netgrif.application.engine.workflow.domain.Task
 import com.netgrif.application.engine.workflow.service.TaskSearchService
 import com.netgrif.application.engine.workflow.service.TaskService
 import com.netgrif.application.engine.workflow.service.interfaces.IDataService
+import com.netgrif.application.engine.workflow.service.interfaces.IWorkflowService
+import com.netgrif.application.engine.workflow.web.PublicTaskController
+import com.netgrif.application.engine.workflow.web.TaskController
 import com.netgrif.application.engine.workflow.web.WorkflowController
 import com.netgrif.application.engine.workflow.web.requestbodies.TaskSearchRequest
 import com.netgrif.application.engine.workflow.web.responsebodies.TaskReference
@@ -29,6 +34,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.data.domain.Page
+import org.springframework.mock.web.MockMultipartFile
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.junit.jupiter.SpringExtension
 
@@ -75,6 +81,12 @@ class TaskControllerTest {
     @Autowired
     private IAuthorityService authorityService
 
+    @Autowired
+    private IWorkflowService workflowService
+
+    @Autowired
+    private TaskController taskController
+
     private PetriNet net
 
     private Case useCase
@@ -102,6 +114,34 @@ class TaskControllerTest {
         testWithRoleAndUserref()
         testWithUserref()
         testWithRole()
+    }
+
+    @Test
+    void testDeleteFile() {
+        Case testCase = helper.createCase("My case", net)
+        String taskId = testCase.tasks.find {it.transition == "1"}.task
+
+        dataService.saveFile(taskId, "file", new MockMultipartFile("test", new byte[] {}))
+        testCase = workflowService.findOne(testCase.stringId)
+        assert testCase.dataSet["file"].value != null
+
+        taskController.deleteFile(taskId, "file")
+        testCase = workflowService.findOne(testCase.stringId)
+        assert testCase.dataSet["file"].value == null
+    }
+
+    @Test
+    void testDeleteFileByName() {
+        Case testCase = helper.createCase("My case", net)
+        String taskId = testCase.tasks.find {it.transition == "1"}.task
+
+        dataService.saveFiles(taskId, "fileList", new MockMultipartFile[] {new MockMultipartFile("test", "test", null, new byte[] {})})
+        testCase = workflowService.findOne(testCase.stringId)
+        assert testCase.dataSet["fileList"].value != null
+
+        taskController.deleteNamedFile(taskId, "fileList", "test")
+        testCase = workflowService.findOne(testCase.stringId)
+        assert ((FileListFieldValue) testCase.dataSet["fileList"].value).namesPaths == null || ((FileListFieldValue) testCase.dataSet["fileList"].value).namesPaths.size() == 0
     }
 
 

--- a/src/test/resources/petriNets/all_data_refs.xml
+++ b/src/test/resources/petriNets/all_data_refs.xml
@@ -114,6 +114,11 @@
         </action>
     </data>
 
+    <data type="fileList">
+        <id>fileList</id>
+        <title>File list</title>
+    </data>
+
     <data type="user">
         <id>user</id>
         <title>User</title>
@@ -252,6 +257,17 @@
             <stretch>false</stretch>
             <dataRef>
                 <id>file</id>
+                <logic>
+                    <behavior>editable</behavior>
+                </logic>
+            </dataRef>
+        </dataGroup>
+        <dataGroup>
+            <id>fileList</id>
+            <title>File list fields</title>
+            <stretch>false</stretch>
+            <dataRef>
+                <id>fileList</id>
                 <logic>
                     <behavior>editable</behavior>
                 </logic>


### PR DESCRIPTION
# Description

When deleting file from file list, set data events were not called.

Fixes [NAE-1626]

## Dependencies

No new dependencies were introduced.

### Third party dependencies

No new dependencies were introduced.

### Blocking Pull requests

There are no dependencies on other PR.

## How Has Been This Tested?

This was tested manually and using unit tests.

### Test Configuration


| Name                | Tested on |
|---------------------| --------- |
| OS                  |   macOS Monterey 12.4        |
| Runtime             |  Java 11        |
| Dependency Manager  |  Maven 3.8.4         |
| Framework version   |  Spring Boot 2.6.2        |
| Run parameters      |           |
| Other configuration |           |


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes have been checked, personally or remotely, with @mladoniczky
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes:
    - [x] Lint test
    - [x] Unit tests
    - [x] Integration tests
- [x] I have checked my contribution with code analysis tools:
    - [x] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_application-engine)
    - [x] [Snyk](https://app.snyk.io/org/netgrif)
- [x] I have made corresponding changes to the documentation:
    - [x] Developer documentation
    - [x] User Guides
    - [x] Migration Guides


[NAE-1626]: https://netgrif.atlassian.net/browse/NAE-1626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ