### PR TITLE
[NAE-1735] Enumeration parsing error when trying to use icons with option keys

### DIFF
--- a/src/main/java/com/netgrif/application/engine/importer/service/ComponentFactory.java
+++ b/src/main/java/com/netgrif/application/engine/importer/service/ComponentFactory.java
@@ -84,13 +84,14 @@ public class ComponentFactory {
 
     private Component resolveComponent(com.netgrif.application.engine.importer.model.Component importComponent, Importer importer, Data data, Field field) throws MissingIconKeyException {
         if (data != null) {
-            if (data.getType() == DataType.ENUMERATION) {
+            if (data.getType() == DataType.ENUMERATION && data.getValues() != null && !data.getValues().isEmpty()) {
                 return new Component(importComponent.getName(), buildPropertyMap(importComponent.getProperties().getProperty()),
                         buildIconsListWithValues(importComponent.getProperties().getOptionIcons().getIcon(), data.getValues().stream().map(importer::toI18NString).collect(Collectors.toSet()), data.getId()));
+            } else if ((data.getType() == DataType.ENUMERATION || data.getType() == DataType.ENUMERATION_MAP) && data.getOptions() != null && !data.getOptions().getOption().isEmpty()) {
+                return new Component(importComponent.getName(), buildPropertyMap(importComponent.getProperties().getProperty()),
+                        buildIconsListWithOptions(importComponent.getProperties().getOptionIcons().getIcon(), data.getOptions().getOption().stream()
+                                .collect(Collectors.toMap(Option::getKey, importer::toI18NString, (o1, o2) -> o1, LinkedHashMap::new)), data.getId()));
             }
-            return new Component(importComponent.getName(), buildPropertyMap(importComponent.getProperties().getProperty()),
-                    buildIconsListWithOptions(importComponent.getProperties().getOptionIcons().getIcon(), data.getOptions().getOption().stream()
-                            .collect(Collectors.toMap(Option::getKey, importer::toI18NString, (o1, o2) -> o1, LinkedHashMap::new)), data.getId()));
         }
         if (field instanceof EnumerationField) {
             return new Component(importComponent.getName(), buildPropertyMap(importComponent.getProperties().getProperty()),


### PR DESCRIPTION
# Description

Resolved enumeration values/options parsing in component resolver.

Fixes [NAE-1735]

## Dependencies

No new dependencies were introduced.

### Third party dependencies

No new dependencies were introduced.

### Blocking Pull requests

There are no dependencies on other PR.

## How Has Been This Tested?

This was tested manually with all_data.xml Petrinet.

### Test Configuration

| Name                | Tested on |
|---------------------| --------- |
| OS                  |   macOS Monterey 12.6        |
| Runtime             |  Java 11        |
| Dependency Manager  |  Maven 3.8.4         |
| Framework version   |  Spring Boot 2.6.2        |
| Run parameters      |           |
| Other configuration |           |


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My changes have been checked, personally or remotely, with @machacjozef 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes:
    - [ ] Lint test
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] I have checked my contribution with code analysis tools:
    - [ ] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_application-engine)
    - [ ] [Snyk](https://app.snyk.io/org/netgrif/project/ea82b3b8-658d-41f5-89a7-76cd600da01f)
- [x] I have made corresponding changes to the documentation:
    - [x] Developer documentation
    - [x] User Guides
    - [x] Migration Guides
