### PR TITLE
[NAE-1748] Incorrect handling for long lines in PDF generator

### DIFF
--- a/src/main/java/com/netgrif/application/engine/pdf/generator/service/fieldbuilder/FieldBuilder.java
+++ b/src/main/java/com/netgrif/application/engine/pdf/generator/service/fieldbuilder/FieldBuilder.java
@@ -109,17 +109,31 @@ public abstract class FieldBuilder {
             while (tokenizer.hasMoreTokens()) {
                 String word = tokenizer.nextToken();
 
-                if (lineLen + word.length() > maxLineLength) {
+                if (word.length() > maxLineLength - lineLen && word.length() > maxLineLength) {
+                    breakLongWordToMultipleLine(output, word, lineLen, (int) maxLineLength);
+                } else if (lineLen + word.length() > maxLineLength) {
                     output.append("\n");
                     lineLen = 0;
+                    output.append(word).append(" ");
+                    lineLen += word.length() + 1;
+                } else {
+                    output.append(word).append(" ");
+                    lineLen += word.length() + 1;
                 }
-                output.append(word).append(" ");
-                lineLen += word.length() + 1;
             }
             lineLen = 0;
             result.addAll(Arrays.asList(output.toString().split("\n")));
         }
         return result;
+    }
+
+    public static void breakLongWordToMultipleLine(StringBuilder output, String longWord, int lineLength, int maxLineLength) {
+        while (longWord.length() > maxLineLength - lineLength) {
+            output.append(longWord, 0, maxLineLength - lineLength - 4);
+            output.append("\n");
+            lineLength = 0;
+            longWord = longWord.substring(maxLineLength - lineLength - 3);
+        }
     }
 
     private int countFieldWidth(DataGroup dataGroup, LocalisedField field) {

--- a/src/main/java/com/netgrif/application/engine/pdf/generator/service/fieldbuilder/FieldBuilder.java
+++ b/src/main/java/com/netgrif/application/engine/pdf/generator/service/fieldbuilder/FieldBuilder.java
@@ -111,6 +111,7 @@ public abstract class FieldBuilder {
 
                 if (word.length() > maxLineLength - lineLen && word.length() > maxLineLength) {
                     breakLongWordToMultipleLine(output, word, lineLen, (int) maxLineLength);
+                    lineLen = 0;
                 } else if (lineLen + word.length() > maxLineLength) {
                     output.append("\n");
                     lineLen = 0;
@@ -128,11 +129,14 @@ public abstract class FieldBuilder {
     }
 
     public static void breakLongWordToMultipleLine(StringBuilder output, String longWord, int lineLength, int maxLineLength) {
+        if (maxLineLength - lineLength <= 0) {
+            lineLength = 0;
+        }
         while (longWord.length() > maxLineLength - lineLength) {
             output.append(longWord, 0, maxLineLength - lineLength - 4);
             output.append("\n");
-            lineLength = 0;
             longWord = longWord.substring(maxLineLength - lineLength - 3);
+            lineLength = 0;
         }
     }
 


### PR DESCRIPTION
# Description

Implemented function for breaking long words (URLs, long file names) into multiline text.

Fixes [NAE-1748]

## Dependencies

No new dependencies were introduced.

### Third party dependencies

No new dependencies were introduced.

### Blocking Pull requests

There are no dependencies on other PR.

## How Has Been This Tested?

This was tested manually and using unit tests.

### Test Configuration

| Name                | Tested on |
|---------------------| --------- |
| OS                  |   macOS Monterey 12.6        |
| Runtime             |  Java 11        |
| Dependency Manager  |  Maven 3.8.4         |
| Framework version   |  Spring Boot 2.6.2        |
| Run parameters      |           |
| Other configuration |           |

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes have been checked, personally or remotely, with @machacjozef 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes:
    - [ ] Lint test
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] I have checked my contribution with code analysis tools:
    - [ ] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_application-engine)
    - [ ] [Snyk](https://app.snyk.io/org/netgrif/project/ea82b3b8-658d-41f5-89a7-76cd600da01f)
- [x] I have made corresponding changes to the documentation:
    - [x] Developer documentation
    - [x] User Guides
    - [x] Migration Guides


[NAE-1748]: https://netgrif.atlassian.net/browse/NAE-1748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ