### PR TITLE
[NAE-1755] PetriNetService cache no caching  "null"

### DIFF
--- a/src/main/java/com/netgrif/application/engine/petrinet/service/PetriNetService.java
+++ b/src/main/java/com/netgrif/application/engine/petrinet/service/PetriNetService.java
@@ -143,7 +143,7 @@ public class PetriNetService implements IPetriNetService {
      * Get read only Petri net.
      */
     @Override
-    @Cacheable(value="petriNetCache", unless="#result != null")
+    @Cacheable(value="petriNetCache", unless="#result == null")
     public PetriNet get(ObjectId petriNetId) {
         Optional<PetriNet> optional = repository.findById(petriNetId.toString());
         if (!optional.isPresent()) {
@@ -240,7 +240,7 @@ public class PetriNetService implements IPetriNetService {
     }
 
     @Override
-    @Cacheable(value="petriNetById", unless="#result != null")
+    @Cacheable(value="petriNetById", unless="#result == null")
     public PetriNet getPetriNet(String id) {
         Optional<PetriNet> net = repository.findById(id);
         if (!net.isPresent())
@@ -251,7 +251,7 @@ public class PetriNetService implements IPetriNetService {
     }
 
     @Override
-    @Cacheable(value = "petriNetByIdentifier", key = "#identifier+#version.toString()", unless="#result != null")
+    @Cacheable(value = "petriNetByIdentifier", key = "#identifier+#version.toString()", unless="#result == null")
     public PetriNet getPetriNet(String identifier, Version version) {
         PetriNet net = repository.findByIdentifierAndVersion(identifier, version);
         if (net == null)
@@ -275,7 +275,7 @@ public class PetriNetService implements IPetriNetService {
     }
 
     @Override
-    @Cacheable(value="petriNetNewest", unless="#result != null")
+    @Cacheable(value="petriNetNewest", unless="#result == null")
     public PetriNet getNewestVersionByIdentifier(String identifier) {
         List<PetriNet> nets = repository.findByIdentifier(identifier, PageRequest.of(0, 1, Sort.Direction.DESC, "version.major", "version.minor", "version.patch")).getContent();
         if (nets.isEmpty())

--- a/src/main/java/com/netgrif/application/engine/petrinet/service/PetriNetService.java
+++ b/src/main/java/com/netgrif/application/engine/petrinet/service/PetriNetService.java
@@ -143,7 +143,7 @@ public class PetriNetService implements IPetriNetService {
      * Get read only Petri net.
      */
     @Override
-    @Cacheable("petriNetCache")
+    @Cacheable(value="petriNetCache", unless="#result != null")
     public PetriNet get(ObjectId petriNetId) {
         Optional<PetriNet> optional = repository.findById(petriNetId.toString());
         if (!optional.isPresent()) {
@@ -240,7 +240,7 @@ public class PetriNetService implements IPetriNetService {
     }
 
     @Override
-    @Cacheable("petriNetById")
+    @Cacheable(value="petriNetById", unless="#result != null")
     public PetriNet getPetriNet(String id) {
         Optional<PetriNet> net = repository.findById(id);
         if (!net.isPresent())
@@ -251,7 +251,7 @@ public class PetriNetService implements IPetriNetService {
     }
 
     @Override
-    @Cacheable(value = "petriNetByIdentifier", key = "#identifier+#version.toString()")
+    @Cacheable(value = "petriNetByIdentifier", key = "#identifier+#version.toString()", unless="#result != null")
     public PetriNet getPetriNet(String identifier, Version version) {
         PetriNet net = repository.findByIdentifierAndVersion(identifier, version);
         if (net == null)
@@ -275,7 +275,7 @@ public class PetriNetService implements IPetriNetService {
     }
 
     @Override
-    @Cacheable("petriNetNewest")
+    @Cacheable(value="petriNetNewest", unless="#result != null")
     public PetriNet getNewestVersionByIdentifier(String identifier) {
         List<PetriNet> nets = repository.findByIdentifier(identifier, PageRequest.of(0, 1, Sort.Direction.DESC, "version.major", "version.minor", "version.patch")).getContent();
         if (nets.isEmpty())

--- a/src/test/groovy/com/netgrif/application/engine/petrinet/service/CachePetriNetServiceTest.groovy
+++ b/src/test/groovy/com/netgrif/application/engine/petrinet/service/CachePetriNetServiceTest.groovy
@@ -67,11 +67,11 @@ class CachePetriNetServiceTest {
 
     @Test
     void cacheTest() {
+        assert cacheManager.getCache(cacheProperties.getPetriNetNewest()).get("processDeleteTest") == null
         ImportPetriNetEventOutcome testNetOptional = petriNetService.importPetriNet(stream(NET_FILE), VersionType.MAJOR, superCreator.getLoggedSuper())
         assert testNetOptional.getNet() != null
         PetriNet testNet = testNetOptional.getNet()
 
-        assert cacheManager.getCache(cacheProperties.getPetriNetNewest()).get(testNet.getIdentifier()) == null
         PetriNet test = petriNetService.getNewestVersionByIdentifier(testNet.getIdentifier())
         assert cacheManager.getCache(cacheProperties.getPetriNetNewest()).get(testNet.getIdentifier()).get().equals(test)
     }

--- a/src/test/groovy/com/netgrif/application/engine/petrinet/service/CachePetriNetServiceTest.groovy
+++ b/src/test/groovy/com/netgrif/application/engine/petrinet/service/CachePetriNetServiceTest.groovy
@@ -72,6 +72,7 @@ class CachePetriNetServiceTest {
         assert testNetOptional.getNet() != null
         PetriNet testNet = testNetOptional.getNet()
 
+        assert cacheManager.getCache(cacheProperties.getPetriNetNewest()).get(testNet.getIdentifier()) == null
         PetriNet test = petriNetService.getNewestVersionByIdentifier(testNet.getIdentifier())
         assert cacheManager.getCache(cacheProperties.getPetriNetNewest()).get(testNet.getIdentifier()).get().equals(test)
     }


### PR DESCRIPTION
# Description

<Please include a summary of the changes and which issue is fixed. Please also include relevant links and special instructions if applicable.>

Fixes [NAE-1755]

## Dependencies


### Third party dependencies

No new dependencies were introduced

### Blocking Pull requests

There are no dependencies on other PR

## How Has Been This Tested?

Manually

### Test Configuration

| Name                | Tested on |
|---------------------| --------- |
| OS                  |   Linux Mint 20.3        |
| Runtime             |  Java 11        |
| Dependency Manager  |  Maven 3.8.4         |
| Framework version   |  Spring Boot 2.7.0     |
| Run parameters      |           |
| Other configuration |           |


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes have been checked, personally or remotely, with @RudeBoyxX     
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes:
    - [x] Lint test
    - [x] Unit tests
    - [x] Integration tests
- [x] I have checked my contribution with code analysis tools:
    - [x] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_application-engine)
    - [x] [Snyk](https://app.snyk.io/org/netgrif/project/ea82b3b8-658d-41f5-89a7-76cd600da01f)
- [x] I have made corresponding changes to the documentation:
    - [x] Developer documentation
    - [x] User Guides
    - [x] Migration Guides



[NAE-1755]: https://netgrif.atlassian.net/browse/NAE-1755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ