### PR TITLE
[NAE-1757] Multichoice and enumeration options not working

### DIFF
--- a/src/main/java/com/netgrif/application/engine/importer/service/FieldFactory.java
+++ b/src/main/java/com/netgrif/application/engine/importer/service/FieldFactory.java
@@ -187,6 +187,7 @@ public final class FieldFactory {
         }
         setDefaultValues(field, data, init -> {
             if (init != null && !init.isEmpty()) {
+                init = init.stream().map(String::trim).collect(Collectors.toList());
                 List<String> finalInits = init.stream().filter(i -> field.getChoices().stream().anyMatch(ch -> ch.getDefaultValue().equals(i))).collect(Collectors.toList());
                 List<String> unresolvedChoices = init.stream().filter(i -> field.getChoices().stream().noneMatch(ch -> ch.getDefaultValue().equals(i))).collect(Collectors.toList());
                 if (!unresolvedChoices.isEmpty()) {


### PR DESCRIPTION
# Description

Implemented parsing of options in case of enumeration and multichoice.

Fixes [NAE-1757]

## Dependencies

No new dependencies were introduced.

### Third party dependencies

No new dependencies were introduced.

### Blocking Pull requests

There are no dependencies on other PR.

## How Has Been This Tested?

This was tested manually.

### Test Configuration

| Name                | Tested on |
|---------------------| --------- |
| OS                  |   macOS Monterey 12.6        |
| Runtime             |  Java 11        |
| Dependency Manager  |  Maven 3.8.4         |
| Framework version   |  Spring Boot 2.6.2        |
| Run parameters      |           |
| Other configuration |           |

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes have been checked, personally or remotely, with @machacjozef 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes:
    - [x] Lint test
    - [x] Unit tests
    - [x] Integration tests
- [x] I have checked my contribution with code analysis tools:
    - [x] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_application-engine)
    - [x] [Snyk](https://app.snyk.io/org/netgrif/project/ea82b3b8-658d-41f5-89a7-76cd600da01f)
- [x] I have made corresponding changes to the documentation:
    - [x] Developer documentation
    - [x] User Guides
    - [x] Migration Guides


[NAE-1757]: https://netgrif.atlassian.net/browse/NAE-1757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ