### PR TITLE
[NAE-1756] Delete PetriNet does not call case delete events

### DIFF
--- a/src/main/groovy/com/netgrif/application/engine/AsyncRunner.groovy
+++ b/src/main/groovy/com/netgrif/application/engine/AsyncRunner.groovy
@@ -10,4 +10,9 @@ class AsyncRunner {
     void run(Closure closure) {
         closure()
     }
+
+    @Async
+    void execute(final Runnable runnable) {
+        runnable.run()
+    }
 }

--- a/src/main/java/com/netgrif/application/engine/elastic/service/ElasticCaseService.java
+++ b/src/main/java/com/netgrif/application/engine/elastic/service/ElasticCaseService.java
@@ -226,6 +226,9 @@ public class ElasticCaseService extends ElasticViewPermissionService implements 
             if (process.identifier != null) {
                 petriNetQuery.should(termQuery("processIdentifier", process.identifier));
             }
+            if (process.processId != null) {
+                petriNetQuery.should(termQuery("processId", process.processId));
+            }
         }
 
         query.filter(petriNetQuery);

--- a/src/main/java/com/netgrif/application/engine/elastic/web/requestbodies/CaseSearchRequest.java
+++ b/src/main/java/com/netgrif/application/engine/elastic/web/requestbodies/CaseSearchRequest.java
@@ -50,6 +50,12 @@ public class CaseSearchRequest {
     public static class PetriNet {
 
         public String identifier;
+
+        public String processId;
+
+        public PetriNet(String identifier) {
+            this.identifier = identifier;
+        }
     }
 
     @Data

--- a/src/main/java/com/netgrif/application/engine/pdf/generator/service/fieldbuilder/TextFieldBuilder.java
+++ b/src/main/java/com/netgrif/application/engine/pdf/generator/service/fieldbuilder/TextFieldBuilder.java
@@ -93,14 +93,9 @@ public class TextFieldBuilder extends FieldBuilder {
     }
 
     private String resolveFileListNames(FileListFieldValue files) {
-        StringBuilder builder = new StringBuilder();
-
-        files.getNamesPaths().forEach(value -> {
-            builder.append(shortenFileName(value.getName()));
-            builder.append(", ");
-        });
-
-        return builder.toString();
+        return files.getNamesPaths().stream()
+                .map(it -> shortenFileName(it.getName()))
+                .collect(Collectors.joining(", "));
     }
 
     private String shortenFileName(String fileName) {

--- a/src/main/java/com/netgrif/application/engine/petrinet/service/interfaces/IPetriNetService.java
+++ b/src/main/java/com/netgrif/application/engine/petrinet/service/interfaces/IPetriNetService.java
@@ -17,6 +17,7 @@ import org.bson.types.ObjectId;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/src/main/java/com/netgrif/application/engine/petrinet/service/interfaces/IPetriNetService.java
+++ b/src/main/java/com/netgrif/application/engine/petrinet/service/interfaces/IPetriNetService.java
@@ -17,7 +17,6 @@ import org.bson.types.ObjectId;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/src/main/java/com/netgrif/application/engine/petrinet/web/PetriNetController.java
+++ b/src/main/java/com/netgrif/application/engine/petrinet/web/PetriNetController.java
@@ -1,5 +1,6 @@
 package com.netgrif.application.engine.petrinet.web;
 
+import com.netgrif.application.engine.AsyncRunner;
 import com.netgrif.application.engine.auth.domain.LoggedUser;
 import com.netgrif.application.engine.eventoutcomes.LocalisedEventOutcomeFactory;
 import com.netgrif.application.engine.importer.service.Importer;
@@ -70,6 +71,9 @@ public class PetriNetController {
 
     @Autowired
     private StringToVersionConverter converter;
+
+    @Autowired
+    private AsyncRunner asyncRunner;
 
     @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Import new process",
@@ -191,7 +195,7 @@ public class PetriNetController {
             return MessageResource.errorMessage("Deleting Petri net " + processId + " failed!");
         }
         LoggedUser user = (LoggedUser) auth.getPrincipal();
-        this.service.deletePetriNet(decodedProcessId, user);
+        asyncRunner.execute(() -> this.service.deletePetriNet(decodedProcessId, user));
         return MessageResource.successMessage("Petri net " + decodedProcessId + " was deleted");
     }
 

--- a/src/main/java/com/netgrif/application/engine/petrinet/web/PetriNetController.java
+++ b/src/main/java/com/netgrif/application/engine/petrinet/web/PetriNetController.java
@@ -196,7 +196,7 @@ public class PetriNetController {
         }
         LoggedUser user = (LoggedUser) auth.getPrincipal();
         asyncRunner.execute(() -> this.service.deletePetriNet(decodedProcessId, user));
-        return MessageResource.successMessage("Petri net " + decodedProcessId + " was deleted");
+        return MessageResource.successMessage("Petri net " + decodedProcessId + " is being deleted");
     }
 
     public static String decodeUrl(String s1) {

--- a/src/main/java/com/netgrif/application/engine/workflow/service/WorkflowService.java
+++ b/src/main/java/com/netgrif/application/engine/workflow/service/WorkflowService.java
@@ -117,9 +117,6 @@ public class WorkflowService implements IWorkflowService {
     @Autowired
     private IUriService uriService;
 
-    @Autowired
-    private AsyncRunner asyncRunner;
-
     protected IElasticCaseService elasticCaseService;
 
     @Autowired

--- a/src/main/java/com/netgrif/application/engine/workflow/service/interfaces/IWorkflowService.java
+++ b/src/main/java/com/netgrif/application/engine/workflow/service/interfaces/IWorkflowService.java
@@ -40,8 +40,6 @@ public interface IWorkflowService {
 
     DeleteCaseEventOutcome deleteCase(String caseId);
 
-    void deleteAllCasesOfNet(PetriNet net);
-
     DeleteCaseEventOutcome deleteSubtreeRootedAt(String caseId);
 
     DeleteCaseEventOutcome deleteCase(Case useCase);

--- a/src/main/java/com/netgrif/application/engine/workflow/service/interfaces/IWorkflowService.java
+++ b/src/main/java/com/netgrif/application/engine/workflow/service/interfaces/IWorkflowService.java
@@ -40,7 +40,11 @@ public interface IWorkflowService {
 
     DeleteCaseEventOutcome deleteCase(String caseId);
 
+    void deleteAllCasesOfNet(PetriNet net);
+
     DeleteCaseEventOutcome deleteSubtreeRootedAt(String caseId);
+
+    DeleteCaseEventOutcome deleteCase(Case useCase);
 
     void deleteInstancesOfPetriNet(PetriNet net);
 


### PR DESCRIPTION
# Description

Deletion of PetriNet is now calling delete events of cases.

Fixes [NAE-1756]

## Dependencies

No new dependencies were introduced.

### Third party dependencies

No new dependencies were introduced.

### Blocking Pull requests

There are no dependencies on other PR.

## How Has Been This Tested?

This was tested manually, and with unit tests.

### Test Configuration

| Name                | Tested on |
|---------------------| --------- |
| OS                  |   macOS Monterey 12.6        |
| Runtime             |  Java 11        |
| Dependency Manager  |  Maven 3.8.4         |
| Framework version   |  Spring Boot 2.6.2        |
| Run parameters      |           |
| Other configuration |           |


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes have been checked, personally or remotely, with @mladoniczky 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes:
    - [x] Lint test
    - [x] Unit tests
    - [x] Integration tests
- [x] I have checked my contribution with code analysis tools:
    - [x] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_application-engine)
    - [x] [Snyk](https://app.snyk.io/org/netgrif/project/ea82b3b8-658d-41f5-89a7-76cd600da01f)
- [x] I have made corresponding changes to the documentation:
    - [x] Developer documentation
    - [x] User Guides
    - [x] Migration Guides


[NAE-1756]: https://netgrif.atlassian.net/browse/NAE-1756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ