### PR TITLE
[NAE-1764] Required staying active when behaviour is set to editable

### DIFF
--- a/src/main/groovy/com/netgrif/application/engine/petrinet/domain/dataset/logic/FieldBehavior.groovy
+++ b/src/main/groovy/com/netgrif/application/engine/petrinet/domain/dataset/logic/FieldBehavior.groovy
@@ -42,7 +42,7 @@ enum FieldBehavior {
             case "visible":
                 return (FieldBehavior[]) [REQUIRED, EDITABLE, HIDDEN, FORBIDDEN].toArray()
             case "editable":
-                return (FieldBehavior[]) [VISIBLE, HIDDEN, FORBIDDEN].toArray()
+                return (FieldBehavior[]) [VISIBLE, HIDDEN, FORBIDDEN, REQUIRED].toArray()
             case "hidden":
                 return (FieldBehavior[]) [EDITABLE, VISIBLE, REQUIRED, FORBIDDEN].toArray()
             case "forbidden":

--- a/src/main/groovy/com/netgrif/application/engine/petrinet/domain/dataset/logic/FieldBehavior.groovy
+++ b/src/main/groovy/com/netgrif/application/engine/petrinet/domain/dataset/logic/FieldBehavior.groovy
@@ -42,7 +42,7 @@ enum FieldBehavior {
             case "visible":
                 return (FieldBehavior[]) [REQUIRED, EDITABLE, HIDDEN, FORBIDDEN].toArray()
             case "editable":
-                return (FieldBehavior[]) [VISIBLE, HIDDEN, FORBIDDEN, REQUIRED].toArray()
+                return (FieldBehavior[]) [VISIBLE, HIDDEN, FORBIDDEN].toArray()
             case "hidden":
                 return (FieldBehavior[]) [EDITABLE, VISIBLE, REQUIRED, FORBIDDEN].toArray()
             case "forbidden":

--- a/src/main/groovy/com/netgrif/application/engine/petrinet/domain/dataset/logic/action/ActionDelegate.groovy
+++ b/src/main/groovy/com/netgrif/application/engine/petrinet/domain/dataset/logic/action/ActionDelegate.groovy
@@ -231,6 +231,12 @@ class ActionDelegate {
         useCase.dataSet.get(field.stringId).makeEditable(trans.stringId)
     }
 
+    def editableOptional = { Field field, Transition trans ->
+        copyBehavior(field, trans)
+        useCase.dataSet.get(field.stringId).makeEditableOptional(trans.stringId)
+    }
+
+
     def required = { Field field, Transition trans ->
         copyBehavior(field, trans)
         useCase.dataSet.get(field.stringId).makeRequired(trans.stringId)

--- a/src/main/java/com/netgrif/application/engine/workflow/domain/DataField.java
+++ b/src/main/java/com/netgrif/application/engine/workflow/domain/DataField.java
@@ -152,6 +152,11 @@ public class DataField implements Referencable {
         changeBehavior(FieldBehavior.EDITABLE, transition);
     }
 
+    public void makeEditableOptional(String transition) {
+        makeOptional(transition);
+        changeBehavior(FieldBehavior.EDITABLE, transition);
+    }
+
     public void makeRequired(String transition) {
         changeBehavior(FieldBehavior.REQUIRED, transition);
     }


### PR DESCRIPTION
# Description

Added REQUIRED to antonyms of EDITABLE.

Fixes [NAE-1764]

## Dependencies

No new dependencies introduced.

### Third party dependencies

No new dependencies introduced.

### Blocking Pull requests

There are no dependencies on other PR.

## How Has Been This Tested?

This was tested manually.

### Test Configuration

| Name                | Tested on |
|---------------------| --------- |
| OS                  |   macOS Monterey 12.6        |
| Runtime             |  Java 11        |
| Dependency Manager  |  Maven 3.8.4         |
| Framework version   |  Spring Boot 2.6.2        |
| Run parameters      |           |
| Other configuration |           |

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes have been checked, personally or remotely, with @machacjozef 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes:
    - [ ] Lint test
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] I have checked my contribution with code analysis tools:
    - [ ] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_application-engine)
    - [ ] [Snyk](https://app.snyk.io/org/netgrif/project/ea82b3b8-658d-41f5-89a7-76cd600da01f)
- [x] I have made corresponding changes to the documentation:
    - [x] Developer documentation
    - [x] User Guides
    - [x] Migration Guides


[NAE-1764]: https://netgrif.atlassian.net/browse/NAE-1764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ