### PR TITLE
[NAE-1798] UserRefs resolves everytime when case is saved

### DIFF
--- a/src/main/groovy/com/netgrif/application/engine/petrinet/domain/dataset/logic/action/ActionDelegate.groovy
+++ b/src/main/groovy/com/netgrif/application/engine/petrinet/domain/dataset/logic/action/ActionDelegate.groovy
@@ -682,6 +682,11 @@ class ActionDelegate {
             field.value = value
             saveChangedValue(field)
         }
+
+        if (field instanceof UserListField) {
+            useCase = workflowService.resolveUserRef(useCase)
+        }
+
         ChangedField changedField = new ChangedField(field.stringId)
         if (field instanceof I18nField) {
             changedField.attributes.put("value", value)

--- a/src/main/groovy/com/netgrif/application/engine/petrinet/domain/dataset/logic/action/ActionDelegate.groovy
+++ b/src/main/groovy/com/netgrif/application/engine/petrinet/domain/dataset/logic/action/ActionDelegate.groovy
@@ -683,10 +683,7 @@ class ActionDelegate {
             saveChangedValue(field)
         }
 
-        if (field instanceof UserListField) {
-            useCase = workflowService.resolveUserRef(useCase)
-        }
-
+        useCase = dataService.applyFieldConnectedChanges(useCase, field)
         ChangedField changedField = new ChangedField(field.stringId)
         if (field instanceof I18nField) {
             changedField.attributes.put("value", value)

--- a/src/main/java/com/netgrif/application/engine/workflow/service/DataService.java
+++ b/src/main/java/com/netgrif/application/engine/workflow/service/DataService.java
@@ -238,6 +238,7 @@ public class DataService implements IDataService {
                         DataEventType.SET, EventPhase.POST, useCase, task));
 
                 historyService.save(new SetDataEventLog(task, useCase, EventPhase.POST, null, user));
+                applyFieldConnectedChanges(useCase, field);
             }
         });
         updateDataset(useCase);
@@ -704,6 +705,16 @@ public class DataService implements IDataService {
                 useCase.getDataSet().put(id, dataField);
             }
         });
+    }
+
+    private void applyFieldConnectedChanges(Case useCase, Field field) {
+        switch (field.getType()) {
+            case USERLIST:
+                workflowService.resolveUserRef(useCase);
+                break;
+            default:
+                break;
+        }
     }
 
     private List<EventOutcome> resolveDataEvents(Field field, DataEventType trigger, EventPhase phase, Case useCase, Task task) {

--- a/src/main/java/com/netgrif/application/engine/workflow/service/DataService.java
+++ b/src/main/java/com/netgrif/application/engine/workflow/service/DataService.java
@@ -707,13 +707,13 @@ public class DataService implements IDataService {
         });
     }
 
-    private void applyFieldConnectedChanges(Case useCase, Field field) {
+    @Override
+    public Case applyFieldConnectedChanges(Case useCase, Field field) {
         switch (field.getType()) {
             case USERLIST:
-                workflowService.resolveUserRef(useCase);
-                break;
+                return workflowService.resolveUserRef(useCase);
             default:
-                break;
+                return useCase;
         }
     }
 

--- a/src/main/java/com/netgrif/application/engine/workflow/service/DataService.java
+++ b/src/main/java/com/netgrif/application/engine/workflow/service/DataService.java
@@ -716,7 +716,7 @@ public class DataService implements IDataService {
         PetriNet petriNet = petriNetService.getPetriNet(useCase.getPetriNetId());
         Optional<Field> field = petriNet.getField(fieldId);
         if (field.isEmpty()) {
-            throw new IllegalArgumentException("Field with given id [" + fieldId + "] does not exists on Petri net [" + petriNet.getTitle().getDefaultValue() + "]");
+            throw new IllegalArgumentException("Field with given id [" + fieldId + "] does not exists on Petri net [" + petriNet.getStringId() + " " + petriNet.getIdentifier() + "]");
         }
         return applyFieldConnectedChanges(useCase, field.get());
     }

--- a/src/main/java/com/netgrif/application/engine/workflow/service/DataService.java
+++ b/src/main/java/com/netgrif/application/engine/workflow/service/DataService.java
@@ -21,6 +21,7 @@ import com.netgrif.application.engine.petrinet.domain.dataset.logic.action.Field
 import com.netgrif.application.engine.petrinet.domain.events.DataEvent;
 import com.netgrif.application.engine.petrinet.domain.events.DataEventType;
 import com.netgrif.application.engine.petrinet.domain.events.EventPhase;
+import com.netgrif.application.engine.petrinet.service.interfaces.IPetriNetService;
 import com.netgrif.application.engine.workflow.domain.Case;
 import com.netgrif.application.engine.workflow.domain.DataField;
 import com.netgrif.application.engine.workflow.domain.EventNotExecutableException;
@@ -86,6 +87,9 @@ public class DataService implements IDataService {
 
     @Autowired
     protected IHistoryService historyService;
+
+    @Autowired
+    protected IPetriNetService petriNetService;
 
     @Value("${nae.image.preview.scaling.px:400}")
     protected int imageScale;
@@ -705,6 +709,16 @@ public class DataService implements IDataService {
                 useCase.getDataSet().put(id, dataField);
             }
         });
+    }
+
+    @Override
+    public Case applyFieldConnectedChanges(Case useCase, String fieldId) {
+        PetriNet petriNet = petriNetService.getPetriNet(useCase.getPetriNetId());
+        Optional<Field> field = petriNet.getField(fieldId);
+        if (field.isEmpty()) {
+            throw new IllegalArgumentException("Field with given id [" + fieldId + "] does not exists on Petri net [" + petriNet.getTitle().getDefaultValue() + "]");
+        }
+        return applyFieldConnectedChanges(useCase, field.get());
     }
 
     @Override

--- a/src/main/java/com/netgrif/application/engine/workflow/service/TaskService.java
+++ b/src/main/java/com/netgrif/application/engine/workflow/service/TaskService.java
@@ -435,7 +435,7 @@ public class TaskService implements ITaskService {
                 executeTransition(task, workflowService.findOne(useCase.getStringId()));
                 return;
             }
-            resolveUserRef(task, useCase);
+            //resolveUserRef(task, useCase);
         }
     }
 

--- a/src/main/java/com/netgrif/application/engine/workflow/service/TaskService.java
+++ b/src/main/java/com/netgrif/application/engine/workflow/service/TaskService.java
@@ -797,7 +797,7 @@ public class TaskService implements ITaskService {
         Task savedTask = save(task);
 
         useCase.addTask(savedTask);
-        workflowService.resolveUserRef(useCase);
+        useCase = workflowService.resolveUserRef(useCase);
         useCase = workflowService.save(useCase);
 
         return savedTask;

--- a/src/main/java/com/netgrif/application/engine/workflow/service/TaskService.java
+++ b/src/main/java/com/netgrif/application/engine/workflow/service/TaskService.java
@@ -435,7 +435,6 @@ public class TaskService implements ITaskService {
                 executeTransition(task, workflowService.findOne(useCase.getStringId()));
                 return;
             }
-            //resolveUserRef(task, useCase);
         }
     }
 

--- a/src/main/java/com/netgrif/application/engine/workflow/service/TaskService.java
+++ b/src/main/java/com/netgrif/application/engine/workflow/service/TaskService.java
@@ -794,10 +794,10 @@ public class TaskService implements ITaskService {
             task.setTransactionId(transaction.getStringId());
         }
 
-        resolveUserRef(task, useCase);
         Task savedTask = save(task);
 
         useCase.addTask(savedTask);
+        workflowService.resolveUserRef(useCase);
         useCase = workflowService.save(useCase);
 
         return savedTask;

--- a/src/main/java/com/netgrif/application/engine/workflow/service/TaskService.java
+++ b/src/main/java/com/netgrif/application/engine/workflow/service/TaskService.java
@@ -796,8 +796,7 @@ public class TaskService implements ITaskService {
         Task savedTask = save(task);
 
         useCase.addTask(savedTask);
-        useCase = workflowService.resolveUserRef(useCase);
-        useCase = workflowService.save(useCase);
+        workflowService.resolveUserRef(useCase);
 
         return savedTask;
     }

--- a/src/main/java/com/netgrif/application/engine/workflow/service/WorkflowService.java
+++ b/src/main/java/com/netgrif/application/engine/workflow/service/WorkflowService.java
@@ -131,8 +131,6 @@ public class WorkflowService implements IWorkflowService {
         }
         encryptDataSet(useCase);
         useCase = repository.save(useCase);
-//        resolveUserRef(useCase);
-//        taskService.resolveUserRef(useCase);
         try {
             setImmediateDataFields(useCase);
             elasticCaseService.indexNow(this.caseMappingService.transform(useCase));
@@ -229,10 +227,12 @@ public class WorkflowService implements IWorkflowService {
 
     private void resolveUserRefPermissions(Case useCase, String userListId, Map<String, Boolean> permission) {
         List<String> userIds = getExistingUsers((UserListFieldValue) useCase.getDataSet().get(userListId).getValue());
-        if (userIds != null && userIds.size() != 0 && permission.containsKey("view") && !permission.get("view")) {
-            useCase.getNegativeViewUsers().addAll(userIds);
-        } else if (userIds != null && userIds.size() != 0) {
-            useCase.addUsers(new HashSet<>(userIds), permission);
+        if (userIds != null && userIds.size() != 0) {
+            if (permission.containsKey("view") && !permission.get("view")) {
+                useCase.getNegativeViewUsers().addAll(userIds);
+            } else {
+                useCase.addUsers(new HashSet<>(userIds), permission);
+            }
         }
     }
 

--- a/src/main/java/com/netgrif/application/engine/workflow/service/WorkflowService.java
+++ b/src/main/java/com/netgrif/application/engine/workflow/service/WorkflowService.java
@@ -222,7 +222,7 @@ public class WorkflowService implements IWorkflowService {
         });
         useCase.resolveViewUsers();
         taskService.resolveUserRef(useCase);
-        return repository.save(useCase);
+        return save(useCase);
     }
 
     private void resolveUserRefPermissions(Case useCase, String userListId, Map<String, Boolean> permission) {

--- a/src/main/java/com/netgrif/application/engine/workflow/service/WorkflowService.java
+++ b/src/main/java/com/netgrif/application/engine/workflow/service/WorkflowService.java
@@ -223,6 +223,7 @@ public class WorkflowService implements IWorkflowService {
             resolveUserRefPermissions(useCase, id, permission);
         });
         useCase.resolveViewUsers();
+        taskService.resolveUserRef(useCase);
         return repository.save(useCase);
     }
 

--- a/src/main/java/com/netgrif/application/engine/workflow/service/interfaces/IDataService.java
+++ b/src/main/java/com/netgrif/application/engine/workflow/service/interfaces/IDataService.java
@@ -60,6 +60,8 @@ public interface IDataService {
 
     UserFieldValue makeUserFieldValue(String id);
 
+    Case applyFieldConnectedChanges(Case useCase, String fieldId);
+
     Case applyFieldConnectedChanges(Case useCase, Field field);
 
     void validateCaseRefValue(List<String> value, List<String> allowedNets) throws IllegalArgumentException;

--- a/src/main/java/com/netgrif/application/engine/workflow/service/interfaces/IDataService.java
+++ b/src/main/java/com/netgrif/application/engine/workflow/service/interfaces/IDataService.java
@@ -60,6 +60,8 @@ public interface IDataService {
 
     UserFieldValue makeUserFieldValue(String id);
 
+    Case applyFieldConnectedChanges(Case useCase, Field field);
+
     void validateCaseRefValue(List<String> value, List<String> allowedNets) throws IllegalArgumentException;
 
 }

--- a/src/test/groovy/com/netgrif/application/engine/action/FilterApiTest.groovy
+++ b/src/test/groovy/com/netgrif/application/engine/action/FilterApiTest.groovy
@@ -123,8 +123,10 @@ class FilterApiTest {
         List<String> taskIds = (defGroup.dataSet[ActionDelegate.ORG_GROUP_FIELD_FILTER_TASKS].value ?: []) as List
         assert !taskIds
 
-        assert workflowService.searchOne(QCase.case$._id.eq(new ObjectId(filter.stringId))) == null
+        Thread.sleep(2000);
+
         assert workflowService.searchOne(QCase.case$._id.eq(new ObjectId(item.stringId))) == null
+        assert workflowService.searchOne(QCase.case$._id.eq(new ObjectId(filter.stringId))) == null
     }
 
 

--- a/src/test/groovy/com/netgrif/application/engine/auth/TaskAuthorizationServiceTest.groovy
+++ b/src/test/groovy/com/netgrif/application/engine/auth/TaskAuthorizationServiceTest.groovy
@@ -345,22 +345,34 @@ class TaskAuthorizationServiceTest {
     @Test
     void testCanAssignWithUsersRef() {
         Case case_ = workflowService.createCase(netWithUserRefs.getStringId(), "Test assign", "", testUser.transformToLoggedUser()).getCase()
-        case_.dataSet["assign_pos_ul"].value = new UserListFieldValue([dataService.makeUserFieldValue(testUser.stringId)])
+        String taskId = (new ArrayList<>(case_.getTasks())).get(0).task
+        case_ = dataService.setData(taskId, ImportHelper.populateDataset([
+                "assign_pos_ul": [
+                        "value": [testUser.stringId],
+                        "type": "userList"
+                ]
+        ] as Map)).getCase()
         workflowService.save(case_)
         sleep(4000)
 
-        assert taskAuthorizationService.canCallAssign(testUser.transformToLoggedUser(), (new ArrayList<>(case_.getTasks())).get(0).task)
+        assert taskAuthorizationService.canCallAssign(testUser.transformToLoggedUser(), taskId)
         workflowService.deleteCase(case_.stringId)
     }
 
     @Test
     void testCannotAssignWithUsersRef() {
         Case case_ = workflowService.createCase(netWithUserRefs.getStringId(), "Test assign", "", testUser.transformToLoggedUser()).getCase()
-        case_.dataSet["assign_neg_ul"].value = new UserListFieldValue([dataService.makeUserFieldValue(testUser.stringId)])
+        String taskId = (new ArrayList<>(case_.getTasks())).get(0).task
+        case_ = dataService.setData(taskId, ImportHelper.populateDataset([
+                "assign_neg_ul": [
+                        "value": [testUser.stringId],
+                        "type": "userList"
+                ]
+        ] as Map)).getCase()
         workflowService.save(case_)
         sleep(4000)
 
-        assert !taskAuthorizationService.canCallAssign(testUser.transformToLoggedUser(), (new ArrayList<>(case_.getTasks())).get(0).task)
+        assert !taskAuthorizationService.canCallAssign(testUser.transformToLoggedUser(), taskId)
         workflowService.deleteCase(case_.stringId)
     }
 
@@ -369,11 +381,17 @@ class TaskAuthorizationServiceTest {
         ProcessRole positiveRole = this.netWithUserRefs.getRoles().values().find(v -> v.getImportId() == "assign_pos_role")
         userService.addRole(testUser, positiveRole.getStringId())
         Case case_ = workflowService.createCase(netWithUserRefs.getStringId(), "Test assign", "", testUser.transformToLoggedUser()).getCase()
-        case_.dataSet["assign_pos_ul"].value = new UserListFieldValue([dataService.makeUserFieldValue(testUser.stringId)])
+        String taskId = (new ArrayList<>(case_.getTasks())).get(0).task
+        case_ = dataService.setData(taskId, ImportHelper.populateDataset([
+                "assign_pos_ul": [
+                        "value": [testUser.stringId],
+                        "type": "userList"
+                ]
+        ] as Map)).getCase()
         workflowService.save(case_)
         sleep(4000)
 
-        assert taskAuthorizationService.canCallAssign(testUser.transformToLoggedUser(), (new ArrayList<>(case_.getTasks())).get(0).task)
+        assert taskAuthorizationService.canCallAssign(testUser.transformToLoggedUser(), taskId)
         userService.removeRole(testUser, positiveRole.getStringId())
         workflowService.deleteCase(case_.stringId)
     }
@@ -407,11 +425,16 @@ class TaskAuthorizationServiceTest {
     @Test
     void testCanFinishWithUsersRef() {
         Case case_ = workflowService.createCase(netWithUserRefs.getStringId(), "Test Finish", "", testUser.transformToLoggedUser()).getCase()
-        case_.dataSet["finish_pos_ul"].value = new UserListFieldValue([dataService.makeUserFieldValue(testUser.stringId)])
+        String taskId = (new ArrayList<>(case_.getTasks())).get(0).task
+        case_ = dataService.setData(taskId, ImportHelper.populateDataset([
+                "finish_pos_ul": [
+                        "value": [testUser.stringId],
+                        "type": "userList"
+                ]
+        ] as Map)).getCase()
         workflowService.save(case_)
         sleep(4000)
 
-        String taskId = (new ArrayList<>(case_.getTasks())).get(0).task
         taskService.assignTask(testUser.transformToLoggedUser(), taskId)
         assert taskAuthorizationService.canCallFinish(testUser.transformToLoggedUser(), taskId)
         workflowService.deleteCase(case_.stringId)
@@ -420,11 +443,16 @@ class TaskAuthorizationServiceTest {
     @Test
     void testCannotFinishWithUsersRef() {
         Case case_ = workflowService.createCase(netWithUserRefs.getStringId(), "Test Finish", "", testUser.transformToLoggedUser()).getCase()
-        case_.dataSet["finish_neg_ul"].value = new UserListFieldValue([dataService.makeUserFieldValue(testUser.stringId)])
+        String taskId = (new ArrayList<>(case_.getTasks())).get(0).task
+        case_ = dataService.setData(taskId, ImportHelper.populateDataset([
+                "finish_neg_ul": [
+                        "value": [testUser.stringId],
+                        "type": "userList"
+                ]
+        ] as Map)).getCase()
         workflowService.save(case_)
         sleep(4000)
 
-        String taskId = (new ArrayList<>(case_.getTasks())).get(0).task
         taskService.assignTask(testUser.transformToLoggedUser(), taskId)
         assert !taskAuthorizationService.canCallFinish(testUser.transformToLoggedUser(), taskId)
         workflowService.deleteCase(case_.stringId)
@@ -435,11 +463,16 @@ class TaskAuthorizationServiceTest {
         ProcessRole positiveRole = this.netWithUserRefs.getRoles().values().find(v -> v.getImportId() == "finish_pos_role")
         userService.addRole(testUser, positiveRole.getStringId())
         Case case_ = workflowService.createCase(netWithUserRefs.getStringId(), "Test Finish", "", testUser.transformToLoggedUser()).getCase()
-        case_.dataSet["finish_pos_ul"].value = new UserListFieldValue([dataService.makeUserFieldValue(testUser.stringId)])
+        String taskId = (new ArrayList<>(case_.getTasks())).get(0).task
+        case_ = dataService.setData(taskId, ImportHelper.populateDataset([
+                "finish_pos_ul": [
+                        "value": [testUser.stringId],
+                        "type": "userList"
+                ]
+        ] as Map)).getCase()
         workflowService.save(case_)
         sleep(4000)
 
-        String taskId = (new ArrayList<>(case_.getTasks())).get(0).task
         taskService.assignTask(testUser.transformToLoggedUser(), taskId)
         assert taskAuthorizationService.canCallFinish(testUser.transformToLoggedUser(), taskId)
         userService.removeRole(testUser, positiveRole.getStringId())

--- a/src/test/groovy/com/netgrif/application/engine/auth/WorkflowAuthorizationServiceTest.groovy
+++ b/src/test/groovy/com/netgrif/application/engine/auth/WorkflowAuthorizationServiceTest.groovy
@@ -227,7 +227,13 @@ class WorkflowAuthorizationServiceTest {
         userService.addRole(testUser, negDeleteRole.getStringId())
 
         Case case_ = workflowService.createCase(netWithUserRefs.getStringId(), "Test delete", "", testUser.transformToLoggedUser()).getCase()
-        case_.dataSet["pos_user_list"].value = new UserListFieldValue([dataService.makeUserFieldValue(testUser.stringId)])
+        String taskId = (new ArrayList<>(case_.getTasks())).get(0).task
+        case_ = dataService.setData(taskId, ImportHelper.populateDataset([
+                "pos_user_list": [
+                        "value": [testUser.stringId],
+                        "type": "userList"
+                ]
+        ] as Map)).getCase()
         workflowService.save(case_)
 
         assert workflowAuthorizationService.canCallDelete(testUser.transformToLoggedUser(), case_.getStringId())
@@ -245,9 +251,17 @@ class WorkflowAuthorizationServiceTest {
         userService.addRole(testUser, negDeleteRole.getStringId())
 
         Case case_ = workflowService.createCase(netWithUserRefs.getStringId(), "Test delete", "", testUser.transformToLoggedUser()).getCase()
-        case_.dataSet["pos_user_list"].value = new UserListFieldValue([dataService.makeUserFieldValue(testUser.stringId)])
-        case_.dataSet["neg_user_list"].value = new UserListFieldValue([dataService.makeUserFieldValue(testUser.stringId)])
-
+        String taskId = (new ArrayList<>(case_.getTasks())).get(0).task
+        case_ = dataService.setData(taskId, ImportHelper.populateDataset([
+                "pos_user_list": [
+                        "value": [testUser.stringId],
+                        "type": "userList"
+                ],
+                "neg_user_list": [
+                        "value": [testUser.stringId],
+                        "type": "userList"
+                ]
+        ] as Map)).getCase()
         workflowService.save(case_)
 
         assert !workflowAuthorizationService.canCallDelete(testUser.transformToLoggedUser(), case_.getStringId())

--- a/src/test/groovy/com/netgrif/application/engine/permissions/ElasticSearchViewPermissionTest.groovy
+++ b/src/test/groovy/com/netgrif/application/engine/permissions/ElasticSearchViewPermissionTest.groovy
@@ -155,7 +155,13 @@ class ElasticSearchViewPermissionTest {
     @Test
     void testSearchElasticViewWithUserWithPosUserRef() {
         Case case_ = workflowService.createCase(netWithUserRefs.getStringId(), "Permission test", "", testUser.transformToLoggedUser()).getCase()
-        case_.dataSet["view_ul_pos"].value = new UserListFieldValue([dataService.makeUserFieldValue(testUser.stringId)])
+        String taskId = (new ArrayList<>(case_.getTasks())).get(0).task
+        case_ = dataService.setData(taskId, ImportHelper.populateDataset([
+                "view_ul_pos": [
+                        "value": [testUser.stringId],
+                        "type": "userList"
+                ]
+        ] as Map)).getCase()
         case_ = workflowService.save(case_)
         sleep(4000)
 
@@ -170,7 +176,13 @@ class ElasticSearchViewPermissionTest {
     @Test
     void testSearchElasticViewWithUserWithNegUserRef() {
         Case case_ = workflowService.createCase(netWithUserRefs.getStringId(), "Permission test", "", testUser.transformToLoggedUser()).getCase()
-        case_.dataSet["view_ul_neg"].value = new UserListFieldValue([dataService.makeUserFieldValue(testUser.stringId)])
+        String taskId = (new ArrayList<>(case_.getTasks())).get(0).task
+        case_ = dataService.setData(taskId, ImportHelper.populateDataset([
+                "view_ul_neg": [
+                        "value": [testUser.stringId],
+                        "type": "userList"
+                ]
+        ] as Map)).getCase()
         case_ = workflowService.save(case_)
         sleep(4000)
 
@@ -187,7 +199,13 @@ class ElasticSearchViewPermissionTest {
         Case case_ = workflowService.createCase(netWithUserRefs.getStringId(), "Permission test", "", testUser.transformToLoggedUser()).getCase()
         ProcessRole negViewRole = this.net.getRoles().values().find(v -> v.getImportId() == "view_neg_role")
         userService.addRole(testUser, negViewRole.getStringId())
-        case_.dataSet["view_ul_pos"].value = new UserListFieldValue([dataService.makeUserFieldValue(testUser.stringId)])
+        String taskId = (new ArrayList<>(case_.getTasks())).get(0).task
+        case_ = dataService.setData(taskId, ImportHelper.populateDataset([
+                "view_ul_pos": [
+                        "value": [testUser.stringId],
+                        "type": "userList"
+                ]
+        ] as Map)).getCase()
         case_ = workflowService.save(case_)
         sleep(4000)
 

--- a/src/test/groovy/com/netgrif/application/engine/permissions/QueryDSLViewPermissionTest.groovy
+++ b/src/test/groovy/com/netgrif/application/engine/permissions/QueryDSLViewPermissionTest.groovy
@@ -139,7 +139,13 @@ class QueryDSLViewPermissionTest {
     @Test
     void testSearchQueryDSLViewWithPosUserRef() {
         Case case_ = workflowService.createCase(netWithUserRefs.getStringId(), "Permission test", "", testUser.transformToLoggedUser()).getCase()
-        case_.dataSet["view_ul_pos"].value = new UserListFieldValue([dataService.makeUserFieldValue(testUser.stringId)])
+        String taskId = (new ArrayList<>(case_.getTasks())).get(0).task
+        case_ = dataService.setData(taskId, ImportHelper.populateDataset([
+                "view_ul_pos": [
+                        "value": [testUser.stringId],
+                        "type": "userList"
+                ]
+        ] as Map)).getCase()
         case_ = workflowService.save(case_)
         sleep(4000)
 
@@ -153,7 +159,13 @@ class QueryDSLViewPermissionTest {
     @Test
     void testSearchTaskQueryDSLViewWithPosUserRef() {
         Case case_ = workflowService.createCase(netWithUserRefs.getStringId(), "Permission test", "", testUser.transformToLoggedUser()).getCase()
-        case_.dataSet["view_ul_pos"].value = new UserListFieldValue([dataService.makeUserFieldValue(testUser.stringId)])
+        String taskId = (new ArrayList<>(case_.getTasks())).get(0).task
+        case_ = dataService.setData(taskId, ImportHelper.populateDataset([
+                "view_ul_pos": [
+                        "value": [testUser.stringId],
+                        "type": "userList"
+                ]
+        ] as Map)).getCase()
         case_ = workflowService.save(case_)
         sleep(4000)
 
@@ -185,7 +197,13 @@ class QueryDSLViewPermissionTest {
     @Test
     void testSearchQueryDSLViewWithNegUserRef() {
         Case case_ = workflowService.createCase(netWithUserRefs.getStringId(), "Permission test", "", testUser.transformToLoggedUser()).getCase()
-        case_.dataSet["view_ul_neg"].value = new UserListFieldValue([dataService.makeUserFieldValue(testUser.stringId)])
+        String taskId = (new ArrayList<>(case_.getTasks())).get(0).task
+        case_ = dataService.setData(taskId, ImportHelper.populateDataset([
+                "view_ul_neg": [
+                        "value": [testUser.stringId],
+                        "type": "userList"
+                ]
+        ] as Map)).getCase()
         case_ = workflowService.save(case_)
         sleep(4000)
 
@@ -199,9 +217,16 @@ class QueryDSLViewPermissionTest {
     @Test
     void testSearchQueryDSLViewWithNegRoleAndPosUserRef() {
         Case case_ = workflowService.createCase(netWithUserRefs.getStringId(), "Permission test", "", testUser.transformToLoggedUser()).getCase()
+        String taskId = (new ArrayList<>(case_.getTasks())).get(0).task
+        case_ = dataService.setData(taskId, ImportHelper.populateDataset([
+                "view_ul_pos": [
+                        "value": [testUser.stringId],
+                        "type": "userList"
+                ]
+        ] as Map)).getCase()
+
         ProcessRole negViewRole = this.net.getRoles().values().find(v -> v.getImportId() == "view_neg_role")
         userService.addRole(testUser, negViewRole.getStringId())
-        case_.dataSet["view_ul_pos"].value = new UserListFieldValue([dataService.makeUserFieldValue(testUser.stringId)])
         case_ = workflowService.save(case_)
         sleep(4000)
 

--- a/src/test/groovy/com/netgrif/application/engine/workflow/UserRefsTest.groovy
+++ b/src/test/groovy/com/netgrif/application/engine/workflow/UserRefsTest.groovy
@@ -64,7 +64,13 @@ class UserRefsTest {
         10.times {
             def _case = importHelper.createCase("$it" as String, it % 2 == 0 ? net : net)
             String id = userService.findByEmail(userEmails[it % 2], true).getStringId()
-            _case.dataSet["user_list_1"].value = new UserListFieldValue([dataService.makeUserFieldValue(id)])
+            String taskId = (new ArrayList<>(_case.getTasks())).get(0).task
+            _case = dataService.setData(taskId, ImportHelper.populateDataset([
+                    "user_list_1": [
+                            "value": [id],
+                            "type": "userList"
+                    ]
+            ] as Map)).getCase()
             newCases.add(workflowService.save(_case))
             userIds.add(id)
         }


### PR DESCRIPTION
# Description

Changed the places of resolution of user references on tasks and cases to only resolve them when case and task is created and when the user list is changed.

Fixes [NAE-1798]

## Dependencies

No new dependencies were introduced.

### Third party dependencies

No new dependencies were introduced.

### Blocking Pull requests

There are no dependencies on other PR.

## How Has Been This Tested?

This was tested manually and with unit tests.

### Test Configuration

| Name                | Tested on |
|---------------------| --------- |
| OS                  |   macOS Ventura 13.0     |
| Runtime             |  Java 11        |
| Dependency Manager  |  Maven 3.8.4         |
| Framework version   |  Spring Boot 2.6.2        |
| Run parameters      |           |
| Other configuration |           |


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes have been checked, personally or remotely, with @mladoniczky 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes:
    - [x] Lint test
    - [x] Unit tests
    - [x] Integration tests
- [x] I have checked my contribution with code analysis tools:
    - [x] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_application-engine)
    - [x] [Snyk](https://app.snyk.io/org/netgrif/project/ea82b3b8-658d-41f5-89a7-76cd600da01f)
- [x] I have made corresponding changes to the documentation:
    - [x] Developer documentation
    - [x] User Guides
    - [x] Migration Guides


[NAE-1798]: https://netgrif.atlassian.net/browse/NAE-1798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ