### PR TITLE
[NAE-1806] Anonymous user password might not be 'null'

### DIFF
--- a/src/main/java/com/netgrif/application/engine/auth/domain/AnonymousUser.java
+++ b/src/main/java/com/netgrif/application/engine/auth/domain/AnonymousUser.java
@@ -22,7 +22,7 @@ public class AnonymousUser extends User {
 
     @Override
     public LoggedUser transformToLoggedUser() {
-        LoggedUser loggedUser = new LoggedUser(this.get_id().toString(), this.getEmail(), this.getPassword(), this.getAuthorities());
+        LoggedUser loggedUser = new LoggedUser(this.get_id().toString(), this.getEmail(), "n/a", this.getAuthorities());
         loggedUser.setFullName(this.getFullName());
         loggedUser.setAnonymous(true);
         if (!this.getProcessRoles().isEmpty())

--- a/src/main/java/com/netgrif/application/engine/auth/domain/LoggedUser.java
+++ b/src/main/java/com/netgrif/application/engine/auth/domain/LoggedUser.java
@@ -80,7 +80,7 @@ public class LoggedUser extends org.springframework.security.core.userdetails.Us
         anonym.setEmail(getUsername());
         anonym.setName("Anonymous");
         anonym.setSurname("User");
-        anonym.setPassword(null);
+        anonym.setPassword("n/a");
         anonym.setState(UserState.ACTIVE);
         anonym.setAuthorities(getAuthorities().stream().map(a -> ((Authority) a)).collect(Collectors.toSet()));
         anonym.setNextGroups(groups.stream().map(String::new).collect(Collectors.toSet()));


### PR DESCRIPTION
# Description

Added default password to anonymous user.

Fixes [NAE-1806]

## Dependencies

No new dependencies were introduced

### Third party dependencies

No new dependencies were introduced

### Blocking Pull requests

There are no dependencies on other PR

## How Has Been This Tested?

This was manually tested.

### Test Configuration

| Name                | Tested on |
|---------------------| --------- |
| OS                  |   macOS Ventura 13.0     |
| Runtime             |  Java 11        |
| Dependency Manager  |  Maven 3.8.4         |
| Framework version   |  Spring Boot 2.6.2        |
| Run parameters      |           |
| Other configuration |           |

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes have been checked, personally or remotely, with @machacjozef 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes:
    - [x] Lint test
    - [x] Unit tests
    - [x] Integration tests
- [x] I have checked my contribution with code analysis tools:
    - [x] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_application-engine)
    - [x] [Snyk](https://app.snyk.io/org/netgrif/project/ea82b3b8-658d-41f5-89a7-76cd600da01f)
- [x] I have made corresponding changes to the documentation:
    - [x] Developer documentation
    - [x] User Guides
    - [x] Migration Guides


[NAE-1806]: https://netgrif.atlassian.net/browse/NAE-1806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ