### PR TITLE
[NAE-1831] Taks with negative permissions displayed

### DIFF
--- a/src/main/java/com/netgrif/application/engine/workflow/service/TaskSearchService.java
+++ b/src/main/java/com/netgrif/application/engine/workflow/service/TaskSearchService.java
@@ -77,7 +77,7 @@ public class TaskSearchService extends MongoSearchService<Task> {
     }
 
     public Predicate viewUsersQuery(String userId) {
-        return QTask.task.viewUserRefs.isEmpty().and(QTask.task.viewRoles.isEmpty()).or(QTask.task.viewUsers.contains(userId));
+        return QTask.task.negativeViewRoles.isEmpty().and(QTask.task.viewUserRefs.isEmpty().and(QTask.task.viewRoles.isEmpty()).or(QTask.task.viewUsers.contains(userId)));
     }
 
     protected Predicate buildNegativeViewRoleQueryConstraint(LoggedUser user) {

--- a/src/main/java/com/netgrif/application/engine/workflow/service/TaskSearchService.java
+++ b/src/main/java/com/netgrif/application/engine/workflow/service/TaskSearchService.java
@@ -77,7 +77,7 @@ public class TaskSearchService extends MongoSearchService<Task> {
     }
 
     public Predicate viewUsersQuery(String userId) {
-        return QTask.task.negativeViewRoles.isEmpty().and(QTask.task.viewUserRefs.isEmpty().and(QTask.task.viewRoles.isEmpty()).or(QTask.task.viewUsers.contains(userId)));
+        return QTask.task.negativeViewRoles.isEmpty().and(QTask.task.viewUserRefs.isEmpty()).and(QTask.task.viewRoles.isEmpty()).or(QTask.task.viewUsers.contains(userId));
     }
 
     protected Predicate buildNegativeViewRoleQueryConstraint(LoggedUser user) {


### PR DESCRIPTION
# Description

Added check for empty negativeViewUsers in TaskSearchService.

Fixes [NAE-1831]

## Dependencies

No new dependencies were introduced.

### Third party dependencies

No new dependencies were introduced.

### Blocking Pull requests

There are no dependencies on other PR.

## How Has Been This Tested?

This was tested manually and with unit tests.

### Test Configuration

| Name                | Tested on |
|---------------------| --------- |
| OS                  |   macOS Ventura 13.2     |
| Runtime             |  Java 11        |
| Dependency Manager  |  Maven 3.8.4         |
| Framework version   |  Spring Boot 2.6.2        |
| Run parameters      |           |
| Other configuration |           |

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My changes have been checked, personally or remotely, with @minop 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes:
    - [ ] Lint test
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] I have checked my contribution with code analysis tools:
    - [ ] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_application-engine)
    - [ ] [Snyk](https://app.snyk.io/org/netgrif/project/ea82b3b8-658d-41f5-89a7-76cd600da01f)
- [x] I have made corresponding changes to the documentation:
    - [x] Developer documentation
    - [x] User Guides
    - [x] Migration Guides


[NAE-1831]: https://netgrif.atlassian.net/browse/NAE-1831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ