### PR TITLE
[NAE-1833] Configuration priority  search

### DIFF
--- a/src/main/java/com/netgrif/application/engine/configuration/ElasticCaseSearchConfiguration.java
+++ b/src/main/java/com/netgrif/application/engine/configuration/ElasticCaseSearchConfiguration.java
@@ -1,6 +1,5 @@
 package com.netgrif.application.engine.configuration;
 
-import com.google.common.collect.ImmutableMap;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
@@ -12,7 +11,7 @@ import java.util.Map;
 @ConfigurationProperties(prefix = "nae.elastic.search.priority")
 public class ElasticCaseSearchConfiguration {
 
-    private Map<String, Float> fullTextFieldMap = ImmutableMap.of(
+    private Map<String, Float> fullTextFieldMap = Map.of(
             "title.keyword", 2f,
             "authorName", 1f,
             "authorEmail", 1f,

--- a/src/main/java/com/netgrif/application/engine/configuration/ElasticCaseSearchConfiguration.java
+++ b/src/main/java/com/netgrif/application/engine/configuration/ElasticCaseSearchConfiguration.java
@@ -1,0 +1,22 @@
+package com.netgrif.application.engine.configuration;
+
+import com.google.common.collect.ImmutableMap;
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Map;
+
+@Data
+@Configuration
+@ConfigurationProperties(prefix = "nae.elastic.search.priority")
+public class ElasticCaseSearchConfiguration {
+
+    private Map<String, Float> fullTextFieldMap = ImmutableMap.of(
+            "title.keyword", 2f,
+            "authorName", 1f,
+            "authorEmail", 1f,
+            "visualId.keyword", 2f
+    );
+
+}

--- a/src/main/java/com/netgrif/application/engine/configuration/ElasticServiceConfiguration.java
+++ b/src/main/java/com/netgrif/application/engine/configuration/ElasticServiceConfiguration.java
@@ -9,12 +9,18 @@ import com.netgrif.application.engine.elastic.service.executors.Executor;
 import com.netgrif.application.engine.elastic.service.interfaces.IElasticCaseService;
 import com.netgrif.application.engine.elastic.service.interfaces.IElasticTaskService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.data.elasticsearch.core.ElasticsearchRestTemplate;
 
 @Configuration
+@ConditionalOnProperty(
+        value = "nae.elastic.service.configuration.enable",
+        matchIfMissing = true,
+        havingValue = "true"
+)
 public class ElasticServiceConfiguration {
 
     @Autowired
@@ -45,7 +51,6 @@ public class ElasticServiceConfiguration {
         return new Executor(elasticsearchProperties.getReindexExecutor().getSize(), elasticsearchProperties.getReindexExecutor().getTimeout());
     }
 
-
     @Bean
     @Primary
     public IElasticCaseService elasticCaseService() {
@@ -68,6 +73,5 @@ public class ElasticServiceConfiguration {
     public IElasticTaskService reindexingTaskElasticTaskService() {
         return new ElasticTaskService(taskRepository, elasticsearchTemplate);
     }
-
 
 }

--- a/src/main/java/com/netgrif/application/engine/elastic/service/ElasticCasePrioritySearch.java
+++ b/src/main/java/com/netgrif/application/engine/elastic/service/ElasticCasePrioritySearch.java
@@ -1,0 +1,21 @@
+package com.netgrif.application.engine.elastic.service;
+
+import com.netgrif.application.engine.configuration.ElasticCaseSearchConfiguration;
+import com.netgrif.application.engine.elastic.service.interfaces.IElasticCasePrioritySearch;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+@Service
+public class ElasticCasePrioritySearch implements IElasticCasePrioritySearch {
+
+
+    @Autowired
+    protected ElasticCaseSearchConfiguration elasticCaseSearchConfiguration;
+
+    @Override
+    public Map<String, Float> fullTextFields() {
+        return elasticCaseSearchConfiguration.getFullTextFieldMap();
+    }
+}

--- a/src/main/java/com/netgrif/application/engine/elastic/service/ElasticCaseService.java
+++ b/src/main/java/com/netgrif/application/engine/elastic/service/ElasticCaseService.java
@@ -1,6 +1,5 @@
 package com.netgrif.application.engine.elastic.service;
 
-import com.google.common.collect.ImmutableMap;
 import com.netgrif.application.engine.auth.domain.LoggedUser;
 import com.netgrif.application.engine.elastic.domain.ElasticCase;
 import com.netgrif.application.engine.elastic.domain.ElasticCaseRepository;
@@ -16,7 +15,6 @@ import com.netgrif.application.engine.workflow.domain.Case;
 import com.netgrif.application.engine.workflow.service.interfaces.IWorkflowService;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.QueryStringQueryBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -51,7 +49,6 @@ public class ElasticCaseService extends ElasticViewPermissionService implements 
     @Value("${spring.data.elasticsearch.index.case}")
     private String caseIndex;
 
-
     @Autowired
     private ElasticsearchRestTemplate template;
 
@@ -74,23 +71,6 @@ public class ElasticCaseService extends ElasticViewPermissionService implements 
     @Lazy
     public void setWorkflowService(IWorkflowService workflowService) {
         this.workflowService = workflowService;
-    }
-
-    private Map<String, Float> fullTextFieldMap = ImmutableMap.of(
-            "title.keyword", 2f,
-            "authorName", 1f,
-            "authorEmail", 1f,
-            "visualId.keyword", 2f
-    );
-
-    /**
-     * See {@link QueryStringQueryBuilder#fields(Map)}
-     *
-     * @return map where keys are ElasticCase field names and values are boosts of these fields
-     */
-    @Override
-    public Map<String, Float> fullTextFields() {
-        return fullTextFieldMap;
     }
 
     @Override
@@ -374,9 +354,6 @@ public class ElasticCaseService extends ElasticViewPermissionService implements 
         query.filter(dataQuery);
     }
 
-    /**
-     * Full text search on fields defined by {@link #fullTextFields()}.
-     */
     private void buildFullTextQuery(CaseSearchRequest request, BoolQueryBuilder query) {
         if (request.fullText == null || request.fullText.isEmpty()) {
             return;

--- a/src/main/java/com/netgrif/application/engine/elastic/service/interfaces/IElasticCasePrioritySearch.java
+++ b/src/main/java/com/netgrif/application/engine/elastic/service/interfaces/IElasticCasePrioritySearch.java
@@ -1,8 +1,15 @@
 package com.netgrif.application.engine.elastic.service.interfaces;
 
+import org.elasticsearch.index.query.QueryStringQueryBuilder;
+
 import java.util.Map;
 
 public interface IElasticCasePrioritySearch {
 
+    /**
+     * See {@link QueryStringQueryBuilder#fields(Map)}
+     *
+     * @return map where keys are ElasticCase field names and values are boosts of these fields
+     */
     Map<String, Float> fullTextFields();
 }

--- a/src/main/java/com/netgrif/application/engine/elastic/service/interfaces/IElasticCasePrioritySearch.java
+++ b/src/main/java/com/netgrif/application/engine/elastic/service/interfaces/IElasticCasePrioritySearch.java
@@ -1,0 +1,8 @@
+package com.netgrif.application.engine.elastic.service.interfaces;
+
+import java.util.Map;
+
+public interface IElasticCasePrioritySearch {
+
+    Map<String, Float> fullTextFields();
+}

--- a/src/main/java/com/netgrif/application/engine/elastic/service/interfaces/IElasticCaseService.java
+++ b/src/main/java/com/netgrif/application/engine/elastic/service/interfaces/IElasticCaseService.java
@@ -23,8 +23,6 @@ public interface IElasticCaseService {
 
     long count(List<CaseSearchRequest> requests, LoggedUser user, Locale locale, Boolean isIntersection);
 
-    Map<String, Float> fullTextFields();
-
     void remove(String caseId);
 
     void removeByPetriNetId(String processId);


### PR DESCRIPTION
# Description

<Please include a summary of the changes and which issue is fixed. Please also include relevant links and special instructions if applicable.>

Implements [NAE-1833]


## Dependencies

No new dependencies were introduced.

### Third party dependencies

No new dependencies were introduced.

### Blocking Pull requests

There are no dependencies on other PR.

## How Has Been This Tested?

This was tested manually and with unit tests.

### Test Configuration

| Name                | Tested on |
|---------------------| --------- |
| OS                  |   macOS Ventura 13.2     |
| Runtime             |  Java 11        |
| Dependency Manager  |  Maven 3.8.4         |
| Framework version   |  Spring Boot 2.6.2        |
| Run parameters      |           |
| Other configuration |           |

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes have been checked, personally or remotely, with @mazarijuraj 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes:
    - [x] Lint test
    - [x] Unit tests
    - [x] Integration tests
- [x] I have checked my contribution with code analysis tools:
    - [x] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_application-engine)
    - [x] [Snyk](https://app.snyk.io/org/netgrif/project/ea82b3b8-658d-41f5-89a7-76cd600da01f)
- [x] I have made corresponding changes to the documentation:
    - [x] Developer documentation
    - [x] User Guides
    - [x] Migration Guides


[NAE-1833]: https://netgrif.atlassian.net/browse/NAE-1833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ