### PR TITLE
[NAE-1853] Passwords loaded from environment variables are shown in application logs

### DIFF
--- a/src/main/java/com/netgrif/application/engine/configuration/PropertyLogger.java
+++ b/src/main/java/com/netgrif/application/engine/configuration/PropertyLogger.java
@@ -17,6 +17,7 @@ import java.util.stream.StreamSupport;
 public class PropertyLogger {
 
     private static final Logger log = LoggerFactory.getLogger(PropertyLogger.class);
+    private static final String[] SECRET_PROPS = new String[]{"secret", "password", "credentials", "heslo", "pass"};
 
     @EventListener
     public void logProperties(ContextRefreshedEvent event) {
@@ -30,8 +31,16 @@ public class PropertyLogger {
                 .map(ps -> ((EnumerablePropertySource) ps).getPropertyNames())
                 .flatMap(Arrays::stream)
                 .distinct()
-                .filter(prop -> !(prop.contains("credentials") || prop.contains("password")))
-                .forEach(prop -> log.info("{}: {}", prop, env.getProperty(prop)));
+                .forEach(prop -> log.info("{}: {}", prop, getSanitizedProperty(prop, env)));
         log.info("===========================================");
+    }
+
+    private String getSanitizedProperty(String property, Environment env) {
+        String value = env.getProperty(property);
+        if (value == null) return "";
+        if (Arrays.stream(SECRET_PROPS).anyMatch(s -> property.toLowerCase().endsWith(s))) {
+            return value.isEmpty() ? "" : "*****";
+        }
+        return value;
     }
 }


### PR DESCRIPTION
# Description

Add sanitization of passwords and secrets in PropertyLogger so there are no leaked passwords in the application log.

Fixes [NAE-1853]

## Dependencies

No new dependencies were introduced

### Blocking Pull requests

There are no dependencies on other PR

## How Has Been This Tested?

Bugfix was tested manually by running the application and searching for password properties.

### Test Configuration


| Name                | Tested on |
|---------------------| --------- |
| OS                  |          Windows 11 |
| Runtime             |         RedHat Java JDK 11  |
| Dependency Manager  |        Maven 3   |
| Framework version   |           |
| Run parameters      |           |
| Other configuration |           |


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes have been checked, personally or remotely, with @...
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have resolved all conflicts with the target branch of the PR
- [ ] I have updated and synced my code with the target branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes:
    - [ ] Lint test
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] I have checked my contribution with code analysis tools:
    - [ ] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_application-engine)
    - [ ] [Snyk](https://app.snyk.io/org/netgrif/project/ea82b3b8-658d-41f5-89a7-76cd600da01f)
- [ ] I have made corresponding changes to the documentation:
    - [ ] Developer documentation
    - [ ] User Guides
    - [ ] Migration Guides
