### PR TITLE
[NAE-1860] Assigning authority to a user via REST API ends up with error

### DIFF
--- a/src/main/groovy/com/netgrif/application/engine/startup/DemoRunner.groovy
+++ b/src/main/groovy/com/netgrif/application/engine/startup/DemoRunner.groovy
@@ -5,15 +5,19 @@ import com.netgrif.application.engine.elastic.domain.ElasticTaskRepository
 import com.netgrif.application.engine.elastic.service.interfaces.IElasticCaseService
 import com.netgrif.application.engine.workflow.domain.repositories.CaseRepository
 import com.netgrif.application.engine.workflow.domain.repositories.TaskRepository
+import com.netgrif.application.engine.workflow.service.interfaces.IDataService
+import com.netgrif.application.engine.workflow.service.interfaces.IWorkflowService
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Component
 
-@Profile("dev")
 @Component
+@Profile("dev")
 class DemoRunner extends AbstractOrderedCommandLineRunner {
+
+    private static final Logger log = LoggerFactory.getLogger(DemoRunner)
 
     @Autowired
     private ImportHelper helper
@@ -33,10 +37,14 @@ class DemoRunner extends AbstractOrderedCommandLineRunner {
     @Autowired
     private ElasticTaskRepository elasticTaskRepository
 
-    private static final Logger log = LoggerFactory.getLogger(DemoRunner)
+    @Autowired
+    private IDataService dataService;
+
+    @Autowired
+    private IWorkflowService workflowService;
 
     @Override
     void run(String... args) throws Exception {
-
+        // Code what is written here DO NOT COMMIT!
     }
 }

--- a/src/main/java/com/netgrif/application/engine/auth/domain/Authority.java
+++ b/src/main/java/com/netgrif/application/engine/auth/domain/Authority.java
@@ -9,6 +9,7 @@ import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.security.core.GrantedAuthority;
 
 import javax.validation.constraints.NotNull;
+import java.util.HashSet;
 import java.util.Set;
 
 @Document
@@ -56,6 +57,9 @@ public class Authority implements GrantedAuthority {
     }
 
     public void addUser(IUser user) {
+        if(users == null) {
+            users = new HashSet<>();
+        }
         users.add(user.getStringId());
     }
 

--- a/src/main/java/com/netgrif/application/engine/auth/service/AbstractUserService.java
+++ b/src/main/java/com/netgrif/application/engine/auth/service/AbstractUserService.java
@@ -54,13 +54,13 @@ public abstract class AbstractUserService implements IUserService {
     }
 
     @Override
-    public void assignAuthority(String userId, String authorityId) {
+    public IUser assignAuthority(String userId, String authorityId) {
         IUser user = resolveById(userId, true);
         Authority authority = authorityService.getOne(authorityId);
         user.addAuthority(authority);
         authority.addUser(user);
 
-        save(user);
+        return save(user);
     }
 
     @Override

--- a/src/main/java/com/netgrif/application/engine/auth/service/UserService.java
+++ b/src/main/java/com/netgrif/application/engine/auth/service/UserService.java
@@ -250,19 +250,19 @@ public class UserService extends AbstractUserService {
     }
 
     @Override
-    public void assignAuthority(String userId, String authorityId) {
+    public IUser assignAuthority(String userId, String authorityId) {
         Optional<User> user = userRepository.findById(userId);
         Optional<Authority> authority = authorityRepository.findById(authorityId);
 
-        if (!user.isPresent())
+        if (user.isEmpty())
             throw new IllegalArgumentException("Could not find user with id [" + userId + "]");
-        if (!authority.isPresent())
+        if (authority.isEmpty())
             throw new IllegalArgumentException("Could not find authority with id [" + authorityId + "]");
 
         user.get().addAuthority(authority.get());
         authority.get().addUser(user.get());
 
-        userRepository.save(user.get());
+        return userRepository.save(user.get());
     }
 
     @Override

--- a/src/main/java/com/netgrif/application/engine/auth/service/interfaces/IUserService.java
+++ b/src/main/java/com/netgrif/application/engine/auth/service/interfaces/IUserService.java
@@ -49,7 +49,7 @@ public interface IUserService {
 
     void addDefaultAuthorities(IUser user);
 
-    void assignAuthority(String userId, String authorityId);
+    IUser assignAuthority(String userId, String authorityId);
 
     IUser getLoggedOrSystem();
 


### PR DESCRIPTION
# Description

 - fix NullPointerException on adding a user to authority property users
 - return saved user entity after assigning it new authority

Fixes [NAE-1860]

## Dependencies

No new dependencies were introduced.

### Blocking Pull requests

There are no dependencies on other PR

## How Has Been This Tested?

Tested manually by performing request POST `localhost:8080/api/user/{id of super user}/authority/assign` and then check the change in the database.

### Test Configuration

| Name                | Tested on |
|---------------------| --------- |
| OS                  |      Windows 11     |
| Runtime             |          Java 11 (RedHat OpenJDK) |
| Dependency Manager  |        Maven 3   |
| Framework version   |        Spring boot 2.7.8   |
| Run parameters      |           |
| Other configuration |           |


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My changes have been checked, personally or remotely, with @...
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes:
    - [ ] Lint test
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] I have checked my contribution with code analysis tools:
    - [ ] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_application-engine)
    - [ ] [Snyk](https://app.snyk.io/org/netgrif/project/ea82b3b8-658d-41f5-89a7-76cd600da01f)
- [ ] I have made corresponding changes to the documentation:
    - [ ] Developer documentation
    - [ ] User Guides
    - [ ] Migration Guides


[NAE-1860]: https://netgrif.atlassian.net/browse/NAE-1860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ