### PR TITLE
[NAE-1870] Indeterministic order in multichoice and multichoice map v…

### DIFF
--- a/src/main/groovy/com/netgrif/application/engine/petrinet/domain/dataset/MultichoiceField.groovy
+++ b/src/main/groovy/com/netgrif/application/engine/petrinet/domain/dataset/MultichoiceField.groovy
@@ -4,7 +4,7 @@ import com.netgrif.application.engine.petrinet.domain.I18nString
 import org.springframework.data.mongodb.core.mapping.Document
 
 @Document
-class MultichoiceField extends ChoiceField<Set<I18nString>> {
+class MultichoiceField extends ChoiceField<LinkedHashSet<I18nString>> {
 
     MultichoiceField() {
         super()
@@ -75,7 +75,7 @@ class MultichoiceField extends ChoiceField<Set<I18nString>> {
     }
 
     @Override
-    void setValue(Set<I18nString> value) {
+    void setValue(LinkedHashSet<I18nString> value) {
         super.setValue(value)
     }
 

--- a/src/main/groovy/com/netgrif/application/engine/petrinet/domain/dataset/MultichoiceField.groovy
+++ b/src/main/groovy/com/netgrif/application/engine/petrinet/domain/dataset/MultichoiceField.groovy
@@ -8,14 +8,14 @@ class MultichoiceField extends ChoiceField<Set<I18nString>> {
 
     MultichoiceField() {
         super()
-        super.setValue(new HashSet<I18nString>())
-        super.setDefaultValue(new HashSet<I18nString>())
+        super.setValue(new LinkedHashSet<I18nString>())
+        super.setDefaultValue(new LinkedHashSet<I18nString>())
     }
 
     MultichoiceField(List<I18nString> values) {
         super(values)
-        super.setValue(new HashSet<I18nString>())
-        super.setDefaultValue(new HashSet<I18nString>())
+        super.setValue(new LinkedHashSet<I18nString>())
+        super.setDefaultValue(new LinkedHashSet<I18nString>())
     }
 
     @Override
@@ -28,7 +28,7 @@ class MultichoiceField extends ChoiceField<Set<I18nString>> {
             this.defaultValue = null
         } else {
             String[] vls = value.split(",")
-            def defaults = new HashSet()
+            def defaults = new LinkedHashSet()
             vls.each { s ->
                 defaults << choices.find { it ->
                     it.defaultValue == s.trim()
@@ -42,7 +42,7 @@ class MultichoiceField extends ChoiceField<Set<I18nString>> {
         if (inits == null || inits.isEmpty()) {
             this.defaultValue = null
         } else {
-            Set<I18nString> defaults = new HashSet<>()
+            Set<I18nString> defaults = new LinkedHashSet<>()
             inits.forEach { initValue ->
                 defaults << choices.find { choice ->
                     choice.defaultValue == initValue.trim()

--- a/src/main/groovy/com/netgrif/application/engine/petrinet/domain/dataset/MultichoiceMapField.groovy
+++ b/src/main/groovy/com/netgrif/application/engine/petrinet/domain/dataset/MultichoiceMapField.groovy
@@ -8,12 +8,12 @@ class MultichoiceMapField extends MapOptionsField<I18nString, Set<String>> {
 
     MultichoiceMapField() {
         super()
-        this.defaultValue = new HashSet<>()
+        this.defaultValue = new LinkedHashSet<>()
     }
 
     MultichoiceMapField(Map<String, I18nString> choices) {
         super(choices)
-        this.defaultValue = new HashSet<>()
+        this.defaultValue = new LinkedHashSet<>()
     }
 
     MultichoiceMapField(Map<String, I18nString> choices, Set<String> defaultValues) {

--- a/src/main/groovy/com/netgrif/application/engine/petrinet/domain/dataset/MultichoiceMapField.groovy
+++ b/src/main/groovy/com/netgrif/application/engine/petrinet/domain/dataset/MultichoiceMapField.groovy
@@ -4,7 +4,7 @@ import com.netgrif.application.engine.petrinet.domain.I18nString
 import org.springframework.data.mongodb.core.mapping.Document
 
 @Document
-class MultichoiceMapField extends MapOptionsField<I18nString, Set<String>> {
+class MultichoiceMapField extends MapOptionsField<I18nString, LinkedHashSet<String>> {
 
     MultichoiceMapField() {
         super()
@@ -16,7 +16,7 @@ class MultichoiceMapField extends MapOptionsField<I18nString, Set<String>> {
         this.defaultValue = new LinkedHashSet<>()
     }
 
-    MultichoiceMapField(Map<String, I18nString> choices, Set<String> defaultValues) {
+    MultichoiceMapField(Map<String, I18nString> choices, LinkedHashSet<String> defaultValues) {
         this(choices)
         this.defaultValue = defaultValues
     }
@@ -37,12 +37,12 @@ class MultichoiceMapField extends MapOptionsField<I18nString, Set<String>> {
     }
 
     @Override
-    Set<String> getDefaultValue() {
+    LinkedHashSet<String> getDefaultValue() {
         return super.getDefaultValue() as Set<String>
     }
 
     @Override
-    void setDefaultValue(Set<String> defaultValue) {
+    void setDefaultValue(LinkedHashSet<String> defaultValue) {
         super.setDefaultValue(defaultValue)
     }
 

--- a/src/main/java/com/netgrif/application/engine/importer/service/FieldFactory.java
+++ b/src/main/java/com/netgrif/application/engine/importer/service/FieldFactory.java
@@ -236,7 +236,7 @@ public final class FieldFactory {
         setFieldOptions(field, data, importer);
         setDefaultValues(field, data, init -> {
             if (init != null && !init.isEmpty()) {
-                field.setDefaultValue(new HashSet<>(init));
+                field.setDefaultValue(new LinkedHashSet<>(init));
             }
         });
         return field;

--- a/src/main/java/com/netgrif/application/engine/importer/service/FieldFactory.java
+++ b/src/main/java/com/netgrif/application/engine/importer/service/FieldFactory.java
@@ -577,7 +577,7 @@ public final class FieldFactory {
     public static Set<I18nString> parseMultichoiceValue(Case useCase, String fieldId) {
         Object values = useCase.getFieldValue(fieldId);
         if (values instanceof ArrayList) {
-            return (Set<I18nString>) ((ArrayList) values).stream().map(val -> new I18nString(val.toString())).collect(Collectors.toSet());
+            return (Set<I18nString>) ((ArrayList) values).stream().map(val -> new I18nString(val.toString())).collect(Collectors.toCollection(LinkedHashSet::new));
         } else {
             return (Set<I18nString>) values;
         }
@@ -586,7 +586,7 @@ public final class FieldFactory {
     public static Set<String> parseMultichoiceMapValue(Case useCase, String fieldId) {
         Object values = useCase.getFieldValue(fieldId);
         if (values instanceof ArrayList) {
-            return (Set<String>) ((ArrayList) values).stream().map(val -> val.toString()).collect(Collectors.toSet());
+            return (Set<String>) ((ArrayList) values).stream().map(val -> val.toString()).collect(Collectors.toCollection( LinkedHashSet::new ));
         } else {
             return (Set<String>) values;
         }

--- a/src/main/java/com/netgrif/application/engine/workflow/service/DataService.java
+++ b/src/main/java/com/netgrif/application/engine/workflow/service/DataService.java
@@ -769,7 +769,7 @@ public class DataService implements IDataService {
                 value = !(node.get("value") == null || node.get("value").isNull()) && node.get("value").asBoolean();
                 break;
             case "multichoice":
-                value = parseMultichoiceFieldValues(node).stream().map(I18nString::new).collect(Collectors.toSet());
+                value = parseMultichoiceFieldValues(node).stream().map(I18nString::new).collect(Collectors.toCollection(LinkedHashSet::new));
                 break;
             case "multichoice_map":
                 value = parseMultichoiceFieldValues(node);
@@ -856,7 +856,7 @@ public class DataService implements IDataService {
 
     private Set<String> parseMultichoiceFieldValues(ObjectNode node) {
         ArrayNode arrayNode = (ArrayNode) node.get("value");
-        HashSet<String> set = new HashSet<>();
+        HashSet<String> set = new LinkedHashSet<>();
         arrayNode.forEach(item -> set.add(item.asText()));
         return set;
     }

--- a/src/main/java/com/netgrif/application/engine/workflow/web/responsebodies/LocalisedMultichoiceMapField.java
+++ b/src/main/java/com/netgrif/application/engine/workflow/web/responsebodies/LocalisedMultichoiceMapField.java
@@ -2,10 +2,10 @@ package com.netgrif.application.engine.workflow.web.responsebodies;
 
 import com.netgrif.application.engine.petrinet.domain.dataset.MultichoiceMapField;
 
+import java.util.LinkedHashSet;
 import java.util.Locale;
-import java.util.Set;
 
-public class LocalisedMultichoiceMapField extends LocalisedMapOptionsField<Set<String>> {
+public class LocalisedMultichoiceMapField extends LocalisedMapOptionsField<LinkedHashSet<String>> {
 
     public LocalisedMultichoiceMapField(MultichoiceMapField field, Locale locale) {
         super(field, locale);


### PR DESCRIPTION
# Description

Fixed order of value in multichoice and multichoice_map autocomplete fields. Insertion order is now applied.

Fixes [NAE-1870]

## Dependencies

No new dependencies were introduced.

### Third party dependencies

No new dependencies were introduced.

### Blocking Pull requests

There are no dependencies on other PR

## How Has Been This Tested?

Manually tested and with unit tests

### Test Configuration

| Name                | Tested on |
|---------------------| --------- |
| OS                  |  Linux Mint 21.1 Cinnamon |
| Runtime             |  Java 11  |
| Dependency Manager  |   Maven 3.8.1  |
| Framework version   |    Spring Boot 2.7.8  |
| Run parameters      |           |
| Other configuration |           |


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes have been checked, personally or remotely, with @tuplle 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes:
    - [x] Lint test
    - [x] Unit tests
    - [x] Integration tests
- [ ] I have checked my contribution with code analysis tools:
    - [ ] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_application-engine)
    - [ ] [Snyk](https://app.snyk.io/org/netgrif/project/ea82b3b8-658d-41f5-89a7-76cd600da01f)
- [x] I have made corresponding changes to the documentation:
    - [x] Developer documentation
    - [x] User Guides
    - [x] Migration Guides


[NAE-1870]: https://netgrif.atlassian.net/browse/NAE-1870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ