### PR TITLE
[NAE-1875] Namespace functions cause memory leak

### DIFF
--- a/src/main/groovy/com/netgrif/application/engine/petrinet/domain/dataset/logic/action/FieldActionsRunner.groovy
+++ b/src/main/groovy/com/netgrif/application/engine/petrinet/domain/dataset/logic/action/FieldActionsRunner.groovy
@@ -58,8 +58,7 @@ abstract class FieldActionsRunner {
             log.error("Action: $action.definition")
             throw e
         }
-        def outcomes = ((ActionDelegate) code.delegate).outcomes
-        return outcomes
+        return ((ActionDelegate) code.delegate).outcomes
     }
 
     Pair<Closure, ActionDelegate> getActionCode(Action action, List<Function> functions, boolean shouldRewriteCachedActions = false) {

--- a/src/test/groovy/com/netgrif/application/engine/petrinet/domain/FunctionsTest.groovy
+++ b/src/test/groovy/com/netgrif/application/engine/petrinet/domain/FunctionsTest.groovy
@@ -202,6 +202,19 @@ class FunctionsTest {
     }
 
     @Test
+    void testNamespaceUseCaseUpdate() {
+        def functionResV2Net = petriNetService.importPetriNet(functionResNetResourceV2.inputStream, VersionType.MAJOR, userService.getLoggedOrSystem().transformToLoggedUser()).getNet()
+        def functionTestV2Net = petriNetService.importPetriNet(functionTestNetResourceV2.inputStream, VersionType.MAJOR, userService.getLoggedOrSystem().transformToLoggedUser()).getNet()
+
+        Case aCase = workflowService.createCase(functionTestV2Net.stringId, "Test", "", userService.getLoggedOrSystem().transformToLoggedUser()).getCase()
+        dataService.setData(aCase.tasks.first().task, ImportHelper.populateDataset(["updateOtherField": ["value": "true", "type": "boolean"]]))
+
+        aCase = workflowService.findOne(aCase.stringId)
+        assert aCase.getFieldValue("toBeUpdated") as Double == 1.0
+        assert aCase.getFieldValue("toBeUpdatedInternally") as Double == 2.0
+    }
+
+    @Test
     void testNamespaceMethodOverloading() {
         testMethodOverloading(functionOverloadingNetResource)
     }

--- a/src/test/resources/petriNets/function_res_v2.xml
+++ b/src/test/resources/petriNets/function_res_v2.xml
@@ -10,6 +10,11 @@
             return x * y
         }
     </function>
+    <function name="updateUseCaseFieldValue" scope="namespace">
+        { def fieldId, def newValue ->
+            change useCase.getField(fieldId) value { newValue }
+        }
+    </function>
     <!-- ROLE -->
     <!-- DATA -->
     <data type="number">

--- a/src/test/resources/petriNets/function_test_v2.xml
+++ b/src/test/resources/petriNets/function_test_v2.xml
@@ -104,6 +104,24 @@
             function_res.createUser(user)
         </action>
     </data>
+    <data type="boolean">
+        <id>updateOtherField</id>
+        <title>Boolean</title>
+        <init>false</init>
+        <action trigger="set">
+            toBeUpdatedInternally: f.toBeUpdatedInternally;
+            function_res.updateUseCaseFieldValue("toBeUpdated", 1)
+            change toBeUpdatedInternally value { (useCase.getFieldValue("toBeUpdated") as Double) + 1.0 }
+        </action>
+    </data>
+    <data type="number">
+        <id>toBeUpdated</id>
+        <title>Number</title>
+    </data>
+    <data type="number">
+        <id>toBeUpdatedInternally</id>
+        <title>Number</title>
+    </data>
     <!-- TRANSITIONS -->
     <transition>
         <id>0</id>


### PR DESCRIPTION
# Description

Fixed problem, where an instance of ActionDelegate couldn't be released off the memory

Fixes [NAE-1875]

## Dependencies

No new dependencies were introduced.

### Third party dependencies

No new dependencies were introduced.

### Blocking Pull requests

There are no dependencies on other PR

## How Has Been This Tested?

Manually and with unit tests. For memory leaks used IntelliJ profiler

### Test Configuration

| Name                | Tested on |
|---------------------| --------- |
| OS                  |  Linux Mint 21.1 Cinnamon |
| Runtime             |  Java 11  |
| Dependency Manager  |   Maven 3.8.1  |
| Framework version   |    Spring Boot 2.7.8  |
| Run parameters      |           |
| Other configuration |           |


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes have been checked, personally or remotely, with @mazarijuraj 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes:
    - [x] Lint test
    - [x] Unit tests
    - [x] Integration tests
- [x] I have checked my contribution with code analysis tools:
    - [x] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_application-engine)
    - [ ] [Snyk](https://app.snyk.io/org/netgrif/project/ea82b3b8-658d-41f5-89a7-76cd600da01f)
- [x] I have made corresponding changes to the documentation:
    - [x] Developer documentation
    - [x] User Guides
    - [x] Migration Guides


[NAE-1875]: https://netgrif.atlassian.net/browse/NAE-1875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ