### PR TITLE
[NAE-1930] Modify Annotation in LdapUser Class for Indexing

### DIFF
--- a/src/main/java/com/netgrif/application/engine/ldap/domain/LdapUser.java
+++ b/src/main/java/com/netgrif/application/engine/ldap/domain/LdapUser.java
@@ -18,7 +18,7 @@ import java.util.Set;
 @ConditionalOnExpression("${nae.ldap.enabled:false}")
 public class LdapUser extends User {
 
-    @Indexed(unique = true)
+    @Indexed
     private String dn;
 
     private String commonName;


### PR DESCRIPTION
- remove problematic unique setting

# Description

removes unique=true designation from Indexed annotation for LdapUser. The reason for this is that users cannot be properly indexed (on property DN) as long as both LdapUser and User classes are saved within the same mongodb collection

Fixes [NAE-1930]

## Dependencies

none

### Third party dependencies

none

### Blocking Pull requests

none

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My changes have been checked, personally or remotely, with @...
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have resolved all conflicts with the target branch of the PR
- [ ] I have updated and synced my code with the target branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes:
    - [ ] Lint test
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] I have checked my contribution with code analysis tools:
    - [ ] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_application-engine)
    - [ ] [Snyk](https://app.snyk.io/org/netgrif/project/ea82b3b8-658d-41f5-89a7-76cd600da01f)
- [ ] I have made corresponding changes to the documentation:
    - [ ] Developer documentation
    - [ ] User Guides
    - [ ] Migration Guides


[NAE-1930]: https://netgrif.atlassian.net/browse/NAE-1930?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ