### PR TITLE
[NAE-1988] Extend Id of processes resource for better resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,14 @@ NAE provides additional components to make integration to your project/environme
 
 * Petriflow low-code language: [http://petriflow.com](https://petriflow.com)
 * Documentation: [https://engine.netgrif.com](https://engine.netgrif.com)
+
 <!-- * Getting Started: [https://engine.netgrif.com/get_started](https://engine.netgrif.com/get_started) -->
+
 * Issue Tracker: [GitHub issues](https://github.com/netgrif/application-engine/issues)
 * Java docs: [https://engine.netgrif.com/javadoc](https://engine.netgrif.com/javadoc)
+
 <!-- * Roadmap: [https://engine.netgrif.com/roadmap](https://engine.netgrif.com/#/roadmap) -->
+
 * License: [NETGRIF Community License](https://netgrif.com/license)
 
 ## Components
@@ -33,7 +37,8 @@ Netgrif Application Engine (or NAE for short) consists of several key components
     * **Process executions** - Process instance and task management
     * [**Actions and Events processing**](https://engine.netgrif.com/#/events/events) - Compiling and running action's
       code, handling events in processes
-    * [**Roles management and permissions resolution**](https://engine.netgrif.com/#/roles/permissions) - Permissions and
+    * [**Roles management and permissions resolution**](https://engine.netgrif.com/#/roles/permissions) - Permissions
+      and
       restrictions resolving for processes
     * [**Search and filters**](https://engine.netgrif.com/#/search/filter) - Indexing, querying and filter management.
 * **Authentication and authorization** - User management and application-wide permissions
@@ -53,11 +58,11 @@ The Application engine has some requirements for runtime environment. The follow
 run and use the engine:
 
 | Name                                                   | Version | Description                                                     | Recommendation                                                         |
-|--------------------------------------------------------|---------|-----------------------------------------------------------------|------------------------------------------------------------------------|
-| [Java](https://openjdk.java.net/)                      | 11+     | Java Development Kit                                            | [OpenJDK 11](https://openjdk.java.net/install/)                        |
-| [Redis](https://redis.io/)                             | 5+      | Key-value in-memory database used for user sessions and caching | [Redis 6.2.6](https://redis.io/download)                               |
-| [MongoDB](https://www.mongodb.com/)                    | 4.4+    | Main document store database                                    | [MongoDB 4.4.11](https://docs.mongodb.com/v4.4/installation/)          |
-| [Elasticsearch](https://www.elastic.co/elasticsearch/) | 7.17+   | Index database used for better application search               | [Elasticsearch 7.17.3](https://www.elastic.co/downloads/past-releases/elasticsearch-7-17-3) |
+|--------------------------------------------------------|---------|-----------------------------------------------------------------|:-----------------------------------------------------------------------|
+| [Java](https://openjdk.java.net/)                      | 21+     | Java Development Kit                                            | [OpenJDK 21](https://openjdk.java.net/install/)                        |
+| [Redis](https://redis.io/)                             | 7+      | Key-value in-memory database used for user sessions and caching | [Redis 7.2.5](https://redis.io/download)                               |
+| [MongoDB](https://www.mongodb.com/)                    | 7+      | Main document store database                                    | [MongoDB 7](hhttps://www.mongodb.com/docs/manual/installation/)        |
+| [Elasticsearch](https://www.elastic.co/elasticsearch/) | 8+      | Index database used for better application search               | [Elasticsearch 8.10.4](https://www.elastic.co/downloads/elasticsearch) |
 
 If you are planning on developing docker container based solution you can use our [docker-compose](docker-compose.yml)
 configuration to run all necessary databases to develop with NAE.
@@ -149,11 +154,6 @@ for building frontend applications in Application Engine platform powered by Pet
 For creating processes in Petriflow language try our free Application Builder
 on [https://builder.netgrif.com](https://builder.netgrif.com). You can start from scratch or import existing process in
 BPMN 2.0 and builder automatically converts it into Petriflow.
-
-### NCLI (Coming soon)
-
-If you need help with setting up project or looking for tool to automate your developer work with NAE based
-applications, take a look on [NCLI (Netgrif Command Line Interface)](https://github.com/netgrif/ncli).
 
 ## Reporting issues
 

--- a/src/main/groovy/com/netgrif/application/engine/petrinet/domain/dataset/logic/action/ActionDelegate.groovy
+++ b/src/main/groovy/com/netgrif/application/engine/petrinet/domain/dataset/logic/action/ActionDelegate.groovy
@@ -42,6 +42,7 @@ import com.netgrif.application.engine.startup.FilterRunner
 import com.netgrif.application.engine.startup.ImportHelper
 import com.netgrif.application.engine.utils.FullPageRequest
 import com.netgrif.application.engine.workflow.domain.Case
+import com.netgrif.application.engine.workflow.domain.ProcessResourceId
 import com.netgrif.application.engine.workflow.domain.QCase
 import com.netgrif.application.engine.workflow.domain.QTask
 import com.netgrif.application.engine.workflow.domain.Task
@@ -1594,7 +1595,7 @@ class ActionDelegate {
         filterCase.setIcon(icon)
         filterCase.dataSet[DefaultFiltersRunner.FILTER_I18N_TITLE_FIELD_ID].value = (title instanceof I18nString) ? title : new I18nString(title as String)
         filterCase = workflowService.save(filterCase)
-        Task newFilterTask = findTask { it._id.eq(new ObjectId(filterCase.tasks.find { it.transition == DefaultFiltersRunner.AUTO_CREATE_TRANSITION }.task)) }
+        Task newFilterTask = findTask { it._id.eq(new ProcessResourceId(filterCase.tasks.find { it.transition == DefaultFiltersRunner.AUTO_CREATE_TRANSITION }.task)) }
         assignTask(newFilterTask)
 
         def setDataMap = [

--- a/src/main/groovy/com/netgrif/application/engine/startup/ImportHelper.groovy
+++ b/src/main/groovy/com/netgrif/application/engine/startup/ImportHelper.groovy
@@ -189,6 +189,8 @@ class ImportHelper {
         return createCase(title, net, superCreator.loggedSuper ?: userService.getSystem().transformToLoggedUser())
     }
 
+    // TODO remove deprecated classes and methods
+    @Deprecated
     boolean createCaseFilter(String title, String query, MergeFilterOperation operation, LoggedUser user) {
         return filterService.saveFilter(new CreateFilterBody(title, Filter.VISIBILITY_PUBLIC, "This filter was created automatically for testing purpose only.", Filter.TYPE_TASK, query), operation, user)
     }

--- a/src/main/java/com/netgrif/application/engine/ApplicationEngine.java
+++ b/src/main/java/com/netgrif/application/engine/ApplicationEngine.java
@@ -11,6 +11,7 @@ import org.aspectj.lang.annotation.Aspect;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
@@ -20,13 +21,15 @@ import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
 import org.springframework.hateoas.config.EnableHypermediaSupport;
 import org.springframework.hateoas.server.LinkRelationProvider;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @EnableCaching
 @EnableHypermediaSupport(type = EnableHypermediaSupport.HypermediaType.HAL)
-@EnableGlobalMethodSecurity(prePostEnabled = true)
+@EnableMethodSecurity
+@ConfigurationPropertiesScan
 @EnableAspectJAutoProxy
 @SpringBootApplication(exclude= {DataSourceAutoConfiguration.class})
 @EnableMongoAuditing

--- a/src/main/java/com/netgrif/application/engine/auth/service/UserService.java
+++ b/src/main/java/com/netgrif/application/engine/auth/service/UserService.java
@@ -10,6 +10,7 @@ import com.netgrif.application.engine.orgstructure.groups.config.GroupConfigurat
 import com.netgrif.application.engine.orgstructure.groups.interfaces.INextGroupService;
 import com.netgrif.application.engine.petrinet.service.interfaces.IProcessRoleService;
 import com.netgrif.application.engine.startup.SystemUserRunner;
+import com.netgrif.application.engine.workflow.domain.ProcessResourceId;
 import com.netgrif.application.engine.workflow.service.interfaces.IFilterImportExportService;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import org.bson.types.ObjectId;
@@ -196,7 +197,7 @@ public class UserService extends AbstractUserService {
     }
 
     @Override
-    public Page<IUser> searchAllCoMembers(String query, List<ObjectId> roleIds, List<ObjectId> negateRoleIds, LoggedUser loggedUser, Boolean small, Pageable pageable) {
+    public Page<IUser> searchAllCoMembers(String query, List<ProcessResourceId> roleIds, List<ProcessResourceId> negateRoleIds, LoggedUser loggedUser, Boolean small, Pageable pageable) {
         if ((roleIds == null || roleIds.isEmpty()) && (negateRoleIds == null || negateRoleIds.isEmpty()))
             return searchAllCoMembers(query, loggedUser, small, pageable);
 

--- a/src/main/java/com/netgrif/application/engine/auth/service/interfaces/IUserService.java
+++ b/src/main/java/com/netgrif/application/engine/auth/service/interfaces/IUserService.java
@@ -5,6 +5,7 @@ import com.netgrif.application.engine.auth.domain.IUser;
 import com.netgrif.application.engine.auth.domain.LoggedUser;
 import com.netgrif.application.engine.auth.web.requestbodies.UpdateUserRequest;
 import com.netgrif.application.engine.petrinet.domain.PetriNet;
+import com.netgrif.application.engine.workflow.domain.ProcessResourceId;
 import org.bson.types.ObjectId;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -71,7 +72,7 @@ public interface IUserService {
 
     void deleteUser(IUser user);
 
-    Page<IUser> searchAllCoMembers(String query, List<ObjectId> roles, List<ObjectId> negateRoleIds, LoggedUser principal, Boolean small, Pageable pageable);
+    Page<IUser> searchAllCoMembers(String query, List<ProcessResourceId> roles, List<ProcessResourceId> negateRoleIds, LoggedUser principal, Boolean small, Pageable pageable);
 
     IUser createSystemUser();
 

--- a/src/main/java/com/netgrif/application/engine/auth/web/PublicUserController.java
+++ b/src/main/java/com/netgrif/application/engine/auth/web/PublicUserController.java
@@ -9,6 +9,7 @@ import com.netgrif.application.engine.auth.web.responsebodies.UserResourceAssemb
 import com.netgrif.application.engine.settings.domain.Preferences;
 import com.netgrif.application.engine.settings.service.IPreferencesService;
 import com.netgrif.application.engine.settings.web.PreferencesResource;
+import com.netgrif.application.engine.workflow.domain.ProcessResourceId;
 import com.netgrif.application.engine.workflow.web.responsebodies.MessageResource;
 import com.netgrif.application.engine.workflow.web.responsebodies.ResourceLinkAssembler;
 import io.swagger.v3.oas.annotations.Operation;
@@ -74,8 +75,8 @@ public class PublicUserController {
     public PagedModel<UserResource> search(@RequestParam(value = "small", required = false) Boolean small, @RequestBody UserSearchRequestBody query, Pageable pageable, PagedResourcesAssembler<IUser> assembler, Locale locale) {
         small = small == null ? false : small;
         Page<IUser> page = userService.searchAllCoMembers(query.getFulltext(),
-                query.getRoles().stream().map(ObjectId::new).collect(Collectors.toList()),
-                query.getNegativeRoles().stream().map(ObjectId::new).collect(Collectors.toList()),
+                query.getRoles().stream().map(ProcessResourceId::new).collect(Collectors.toList()),
+                query.getNegativeRoles().stream().map(ProcessResourceId::new).collect(Collectors.toList()),
                 userService.getAnonymousLogged(), small, pageable);
 
         Link selfLink = WebMvcLinkBuilder.linkTo(WebMvcLinkBuilder.methodOn(PublicUserController.class)

--- a/src/main/java/com/netgrif/application/engine/auth/web/UserController.java
+++ b/src/main/java/com/netgrif/application/engine/auth/web/UserController.java
@@ -18,6 +18,7 @@ import com.netgrif.application.engine.security.service.ISecurityContextService;
 import com.netgrif.application.engine.settings.domain.Preferences;
 import com.netgrif.application.engine.settings.service.IPreferencesService;
 import com.netgrif.application.engine.settings.web.PreferencesResource;
+import com.netgrif.application.engine.workflow.domain.ProcessResourceId;
 import com.netgrif.application.engine.workflow.web.responsebodies.MessageResource;
 import com.netgrif.application.engine.workflow.web.responsebodies.ResourceLinkAssembler;
 import io.swagger.v3.oas.annotations.Operation;
@@ -109,8 +110,8 @@ public class UserController {
     @PostMapping(value = "/search", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaTypes.HAL_JSON_VALUE)
     public PagedModel<UserResource> search(@RequestParam(value = "small", required = false) Boolean small, @RequestBody UserSearchRequestBody query, Pageable pageable, PagedResourcesAssembler<IUser> assembler, Authentication auth, Locale locale) {
         small = small == null ? false : small;
-        List<ObjectId> roles = query.getRoles() == null ? null : query.getRoles().stream().map(ObjectId::new).collect(Collectors.toList());
-        List<ObjectId> negativeRoles = query.getNegativeRoles() == null ? null : query.getNegativeRoles().stream().map(ObjectId::new).collect(Collectors.toList());
+        List<ProcessResourceId> roles = query.getRoles() == null ? null : query.getRoles().stream().map(ProcessResourceId::new).collect(Collectors.toList());
+        List<ProcessResourceId> negativeRoles = query.getNegativeRoles() == null ? null : query.getNegativeRoles().stream().map(ProcessResourceId::new).collect(Collectors.toList());
         Page<IUser> page = userService.searchAllCoMembers(query.getFulltext(),
                 roles,
                 negativeRoles,

--- a/src/main/java/com/netgrif/application/engine/history/domain/baseevent/EventLog.java
+++ b/src/main/java/com/netgrif/application/engine/history/domain/baseevent/EventLog.java
@@ -1,6 +1,7 @@
 package com.netgrif.application.engine.history.domain.baseevent;
 
 import com.netgrif.application.engine.petrinet.domain.events.EventPhase;
+import com.netgrif.application.engine.workflow.domain.ProcessResourceId;
 import lombok.Getter;
 import lombok.Setter;
 import org.bson.types.ObjectId;
@@ -17,7 +18,7 @@ public abstract class EventLog {
     protected ObjectId id;
 
     @Getter
-    protected ObjectId triggerId;
+    protected ProcessResourceId triggerId;
 
     @Getter
     protected EventPhase eventPhase;
@@ -30,13 +31,13 @@ public abstract class EventLog {
         this.id = new ObjectId();
     }
 
-    protected EventLog(ObjectId triggerId, EventPhase eventPhase) {
+    protected EventLog(ProcessResourceId triggerId, EventPhase eventPhase) {
         this();
         this.triggerId = triggerId;
         this.eventPhase = eventPhase;
     }
 
-    protected EventLog(ObjectId triggerId, EventPhase eventPhase, List<ObjectId> triggeredEvents) {
+    protected EventLog(ProcessResourceId triggerId, EventPhase eventPhase, List<ObjectId> triggeredEvents) {
         this(triggerId, eventPhase);
         this.triggeredEvents = triggeredEvents;
     }

--- a/src/main/java/com/netgrif/application/engine/history/domain/caseevents/CaseEventLog.java
+++ b/src/main/java/com/netgrif/application/engine/history/domain/caseevents/CaseEventLog.java
@@ -3,6 +3,7 @@ package com.netgrif.application.engine.history.domain.caseevents;
 import com.netgrif.application.engine.history.domain.petrinetevents.PetriNetEventLog;
 import com.netgrif.application.engine.petrinet.domain.events.EventPhase;
 import com.netgrif.application.engine.workflow.domain.Case;
+import com.netgrif.application.engine.workflow.domain.ProcessResourceId;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.bson.types.ObjectId;
@@ -29,7 +30,7 @@ public abstract class CaseEventLog extends PetriNetEventLog {
         this(useCase.get_id(), useCase, eventPhase);
     }
 
-    protected CaseEventLog(ObjectId triggerId, Case useCase, EventPhase eventPhase) {
+    protected CaseEventLog(ProcessResourceId triggerId, Case useCase, EventPhase eventPhase) {
         super(triggerId, eventPhase, useCase.getPetriNetObjectId());
         this.caseId = useCase.getStringId();
         this.caseTitle = useCase.getTitle();

--- a/src/main/java/com/netgrif/application/engine/history/domain/petrinetevents/DeletePetriNetEventLog.java
+++ b/src/main/java/com/netgrif/application/engine/history/domain/petrinetevents/DeletePetriNetEventLog.java
@@ -1,6 +1,7 @@
 package com.netgrif.application.engine.history.domain.petrinetevents;
 
 import com.netgrif.application.engine.petrinet.domain.events.EventPhase;
+import com.netgrif.application.engine.workflow.domain.ProcessResourceId;
 import lombok.EqualsAndHashCode;
 import org.bson.types.ObjectId;
 import org.springframework.data.mongodb.core.mapping.Document;
@@ -9,7 +10,7 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @EqualsAndHashCode(callSuper = true)
 public class DeletePetriNetEventLog extends PetriNetEventLog {
 
-    public DeletePetriNetEventLog(ObjectId triggerId, EventPhase eventPhase, ObjectId netId) {
+    public DeletePetriNetEventLog(ProcessResourceId triggerId, EventPhase eventPhase, ObjectId netId) {
         super(triggerId, eventPhase, netId);
     }
 }

--- a/src/main/java/com/netgrif/application/engine/history/domain/petrinetevents/ImportPetriNetEventLog.java
+++ b/src/main/java/com/netgrif/application/engine/history/domain/petrinetevents/ImportPetriNetEventLog.java
@@ -1,6 +1,7 @@
 package com.netgrif.application.engine.history.domain.petrinetevents;
 
 import com.netgrif.application.engine.petrinet.domain.events.EventPhase;
+import com.netgrif.application.engine.workflow.domain.ProcessResourceId;
 import lombok.EqualsAndHashCode;
 import org.bson.types.ObjectId;
 import org.springframework.data.mongodb.core.mapping.Document;
@@ -9,7 +10,7 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @EqualsAndHashCode(callSuper = true)
 public class ImportPetriNetEventLog extends PetriNetEventLog {
 
-    public ImportPetriNetEventLog(ObjectId triggerId, EventPhase eventPhase, ObjectId netId) {
+    public ImportPetriNetEventLog(ProcessResourceId triggerId, EventPhase eventPhase, ObjectId netId) {
         super(triggerId, eventPhase, netId);
     }
 }

--- a/src/main/java/com/netgrif/application/engine/history/domain/petrinetevents/PetriNetEventLog.java
+++ b/src/main/java/com/netgrif/application/engine/history/domain/petrinetevents/PetriNetEventLog.java
@@ -2,6 +2,7 @@ package com.netgrif.application.engine.history.domain.petrinetevents;
 
 import com.netgrif.application.engine.history.domain.baseevent.EventLog;
 import com.netgrif.application.engine.petrinet.domain.events.EventPhase;
+import com.netgrif.application.engine.workflow.domain.ProcessResourceId;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import org.bson.types.ObjectId;
@@ -18,12 +19,12 @@ public abstract class PetriNetEventLog extends EventLog {
         super();
     }
 
-    protected PetriNetEventLog(ObjectId triggerId, EventPhase eventPhase, ObjectId netId) {
+    protected PetriNetEventLog(ProcessResourceId triggerId, EventPhase eventPhase, ObjectId netId) {
         super(triggerId, eventPhase);
         this.netId = netId;
     }
 
-    protected PetriNetEventLog(ObjectId triggerId, EventPhase eventPhase, List<ObjectId> triggeredEvents, ObjectId netId) {
+    protected PetriNetEventLog(ProcessResourceId triggerId, EventPhase eventPhase, List<ObjectId> triggeredEvents, ObjectId netId) {
         super(triggerId, eventPhase, triggeredEvents);
         this.netId = netId;
     }

--- a/src/main/java/com/netgrif/application/engine/importer/service/Importer.java
+++ b/src/main/java/com/netgrif/application/engine/importer/service/Importer.java
@@ -33,6 +33,7 @@ import com.netgrif.application.engine.petrinet.service.ArcFactory;
 import com.netgrif.application.engine.petrinet.service.interfaces.IPetriNetService;
 import com.netgrif.application.engine.petrinet.service.interfaces.IProcessRoleService;
 import com.netgrif.application.engine.workflow.domain.FileStorageConfiguration;
+import com.netgrif.application.engine.workflow.domain.ProcessResourceId;
 import com.netgrif.application.engine.workflow.domain.triggers.Trigger;
 import com.netgrif.application.engine.workflow.service.interfaces.IFieldActionsCacheService;
 import lombok.Getter;
@@ -1065,7 +1066,7 @@ public class Importer {
         } else {
             role.setName(toI18NString(importRole.getName()));
         }
-        role.set_id(new ObjectId());
+        role.set_id(new ProcessResourceId(new ObjectId(net.getStringId())));
 
         role.setNetId(net.getStringId());
         net.addRole(role);

--- a/src/main/java/com/netgrif/application/engine/orgstructure/groups/NextGroupService.java
+++ b/src/main/java/com/netgrif/application/engine/orgstructure/groups/NextGroupService.java
@@ -16,6 +16,7 @@ import com.netgrif.application.engine.petrinet.service.interfaces.IPetriNetServi
 import com.netgrif.application.engine.security.service.ISecurityContextService;
 import com.netgrif.application.engine.startup.ImportHelper;
 import com.netgrif.application.engine.workflow.domain.Case;
+import com.netgrif.application.engine.workflow.domain.ProcessResourceId;
 import com.netgrif.application.engine.workflow.domain.QCase;
 import com.netgrif.application.engine.workflow.domain.Task;
 import com.netgrif.application.engine.workflow.domain.eventoutcomes.caseoutcomes.CreateCaseEventOutcome;
@@ -123,7 +124,7 @@ public class NextGroupService implements INextGroupService {
 
     @Override
     public Case findGroup(String groupID) {
-        Case result = workflowService.searchOne(groupCase().and(QCase.case$._id.eq(new ObjectId(groupID))));
+        Case result = workflowService.searchOne(groupCase().and(QCase.case$._id.eq(new ProcessResourceId(groupID))));
         if (!isGroupCase(result)) {
             return null;
         }
@@ -150,7 +151,7 @@ public class NextGroupService implements INextGroupService {
 
     @Override
     public List<Case> findByIds(Collection<String> groupIds) {
-        List<BooleanExpression> groupQueries = groupIds.stream().map(ObjectId::new).map(QCase.case$._id::eq).collect(Collectors.toList());
+        List<BooleanExpression> groupQueries = groupIds.stream().map(ProcessResourceId::new).map(QCase.case$._id::eq).collect(Collectors.toList());
         BooleanBuilder builder = new BooleanBuilder();
         groupQueries.forEach(builder::or);
         return this.workflowService.searchAll(groupCase().and(builder)).getContent();

--- a/src/main/java/com/netgrif/application/engine/petrinet/domain/roles/ProcessRole.java
+++ b/src/main/java/com/netgrif/application/engine/petrinet/domain/roles/ProcessRole.java
@@ -5,6 +5,7 @@ import com.netgrif.application.engine.petrinet.domain.Imported;
 import com.netgrif.application.engine.petrinet.domain.dataset.logic.action.Action;
 import com.netgrif.application.engine.petrinet.domain.events.Event;
 import com.netgrif.application.engine.petrinet.domain.events.EventType;
+import com.netgrif.application.engine.workflow.domain.ProcessResourceId;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
@@ -28,7 +29,7 @@ public class ProcessRole extends Imported {
 
     @Id
     @Setter
-    private ObjectId _id;
+    private ProcessResourceId _id;
 
     private I18nString name;
 
@@ -44,11 +45,15 @@ public class ProcessRole extends Imported {
     private Map<EventType, Event> events;
 
     public ProcessRole() {
-        _id = new ObjectId();
+        if (this.getNetId() == null) {
+            _id = new ProcessResourceId();
+        } else {
+            _id = new ProcessResourceId(new ObjectId(this.getNetId()));
+        }
     }
 
     public ProcessRole(String id) {
-        _id = new ObjectId(id);
+        _id = new ProcessResourceId(id);
     }
 
     @EqualsAndHashCode.Include
@@ -56,16 +61,16 @@ public class ProcessRole extends Imported {
         return _id.toString();
     }
 
-    public ObjectId get_id() {
+    public ProcessResourceId get_id() {
         return _id;
     }
 
-    public void set_id(ObjectId _id) {
+    public void set_id(ProcessResourceId _id) {
         this._id = _id;
     }
 
     public void set_id(String id) {
-        this._id = new ObjectId(id);
+        this._id = new ProcessResourceId(id);
     }
 
     public I18nString getName() {

--- a/src/main/java/com/netgrif/application/engine/petrinet/domain/roles/ProcessRoleRepository.java
+++ b/src/main/java/com/netgrif/application/engine/petrinet/domain/roles/ProcessRoleRepository.java
@@ -1,5 +1,6 @@
 package com.netgrif.application.engine.petrinet.domain.roles;
 
+import com.netgrif.application.engine.workflow.domain.ProcessResourceId;
 import org.bson.types.ObjectId;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
@@ -19,5 +20,5 @@ public interface ProcessRoleRepository extends MongoRepository<ProcessRole, Stri
 
     Set<ProcessRole> findAllByImportId(String importId);
 
-    void deleteAllBy_idIn(Collection<ObjectId> ids);
+    void deleteAllBy_idIn(Collection<ProcessResourceId> ids);
 }

--- a/src/main/java/com/netgrif/application/engine/petrinet/service/PetriNetService.java
+++ b/src/main/java/com/netgrif/application/engine/petrinet/service/PetriNetService.java
@@ -74,63 +74,63 @@ import static com.netgrif.application.engine.petrinet.service.interfaces.IPetriN
 public class PetriNetService implements IPetriNetService {
 
     @Autowired
-    private IProcessRoleService processRoleService;
+    protected IProcessRoleService processRoleService;
 
     @Autowired
-    private PetriNetRepository repository;
+    protected PetriNetRepository repository;
 
     @Autowired
-    private MongoTemplate mongoTemplate;
+    protected MongoTemplate mongoTemplate;
 
     @Autowired
-    private FileStorageConfiguration fileStorageConfiguration;
+    protected FileStorageConfiguration fileStorageConfiguration;
 
     @Autowired
-    private IRuleEngine ruleEngine;
+    protected IRuleEngine ruleEngine;
 
     @Autowired
-    private IWorkflowService workflowService;
+    protected IWorkflowService workflowService;
 
     @Autowired
-    private INextGroupService groupService;
+    protected INextGroupService groupService;
 
     @Autowired
-    private ObjectFactory<Importer> importerObjectFactory;
+    protected ObjectFactory<Importer> importerObjectFactory;
 
     @Autowired
-    private FieldActionsRunner actionsRunner;
+    protected FieldActionsRunner actionsRunner;
 
     @Autowired(required = false)
-    private ILdapGroupRefService ldapGroupService;
+    protected ILdapGroupRefService ldapGroupService;
 
     @Autowired
-    private IFieldActionsCacheService functionCacheService;
+    protected IFieldActionsCacheService functionCacheService;
 
     @Autowired
-    private IUserService userService;
+    protected IUserService userService;
 
     @Autowired
-    private IEventService eventService;
+    protected IEventService eventService;
 
     @Autowired
-    private IHistoryService historyService;
+    protected IHistoryService historyService;
 
     @Autowired
-    private CacheManager cacheManager;
+    protected CacheManager cacheManager;
 
     @Autowired
-    private CacheProperties cacheProperties;
+    protected CacheProperties cacheProperties;
 
     @Resource
-    private IPetriNetService self;
+    protected IPetriNetService self;
 
     @Autowired
-    private IElasticPetriNetMappingService petriNetMappingService;
+    protected IElasticPetriNetMappingService petriNetMappingService;
 
     @Autowired
-    private IUriService uriService;
+    protected IUriService uriService;
 
-    private IElasticPetriNetService elasticPetriNetService;
+    protected IElasticPetriNetService elasticPetriNetService;
 
     @Autowired
     public void setElasticPetriNetService(IElasticPetriNetService elasticPetriNetService) {

--- a/src/main/java/com/netgrif/application/engine/petrinet/service/ProcessRoleService.java
+++ b/src/main/java/com/netgrif/application/engine/petrinet/service/ProcessRoleService.java
@@ -17,6 +17,7 @@ import com.netgrif.application.engine.petrinet.domain.roles.ProcessRoleRepositor
 import com.netgrif.application.engine.petrinet.service.interfaces.IPetriNetService;
 import com.netgrif.application.engine.petrinet.service.interfaces.IProcessRoleService;
 import com.netgrif.application.engine.security.service.ISecurityContextService;
+import com.netgrif.application.engine.workflow.domain.ProcessResourceId;
 import org.bson.types.ObjectId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -288,8 +289,8 @@ public class ProcessRoleService implements IProcessRoleService {
     @Override
     public void deleteRolesOfNet(PetriNet net, LoggedUser loggedUser) {
         log.info("[" + net.getStringId() + "]: Initiating deletion of all roles of Petri net " + net.getIdentifier() + " version " + net.getVersion().toString());
-        List<ObjectId> deletedRoleIds = this.findAll(net).stream().map(ProcessRole::get_id).collect(Collectors.toList());
-        Set<String> deletedRoleStringIds = deletedRoleIds.stream().map(ObjectId::toString).collect(Collectors.toSet());
+        List<ProcessResourceId> deletedRoleIds = this.findAll(net).stream().map(ProcessRole::get_id).collect(Collectors.toList());
+        Set<String> deletedRoleStringIds = deletedRoleIds.stream().map(ProcessResourceId::toString).collect(Collectors.toSet());
 
         List<IUser> usersWithRemovedRoles = this.userService.findAllByProcessRoles(deletedRoleStringIds, false);
         for (IUser user : usersWithRemovedRoles) {

--- a/src/main/java/com/netgrif/application/engine/workflow/domain/Case.java
+++ b/src/main/java/com/netgrif/application/engine/workflow/domain/Case.java
@@ -7,7 +7,6 @@ import com.netgrif.application.engine.petrinet.domain.PetriNet;
 import com.netgrif.application.engine.petrinet.domain.dataset.*;
 import com.netgrif.application.engine.petrinet.domain.roles.RolePermission;
 import com.netgrif.application.engine.workflow.service.interfaces.IInitValueExpressionEvaluator;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import org.bson.types.ObjectId;
@@ -31,7 +30,7 @@ public class Case implements Serializable {
 
     @Id
     @Getter
-    private ObjectId _id;
+    private ProcessResourceId _id;
 
     @Getter
     @Setter
@@ -127,12 +126,10 @@ public class Case implements Serializable {
 
     @Getter
     @Setter
-    @Builder.Default
     private Map<String, Map<String, Boolean>> userRefs = new HashMap<>();
 
     @Getter
     @Setter
-    @Builder.Default
     private Map<String, Map<String, Boolean>> users = new HashMap<>();
 
     @Getter
@@ -162,13 +159,11 @@ public class Case implements Serializable {
     private Map<String, String> tags;
 
     protected Case() {
-        _id = new ObjectId();
         activePlaces = new HashMap<>();
         dataSet = new LinkedHashMap<>();
         immediateDataFields = new LinkedHashSet<>();
         consumedTokens = new HashMap<>();
         tasks = new HashSet<>();
-        visualId = generateVisualId();
         enabledRoles = new HashSet<>();
         permissions = new HashMap<>();
         userRefs = new HashMap<>();
@@ -183,6 +178,7 @@ public class Case implements Serializable {
 
     public Case(PetriNet petriNet) {
         this();
+        this._id = new ProcessResourceId(petriNet.getObjectId());
         petriNetObjectId = petriNet.getObjectId();
         processIdentifier = petriNet.getIdentifier();
         this.petriNet = petriNet;

--- a/src/main/java/com/netgrif/application/engine/workflow/domain/ProcessResourceId.java
+++ b/src/main/java/com/netgrif/application/engine/workflow/domain/ProcessResourceId.java
@@ -1,0 +1,129 @@
+package com.netgrif.application.engine.workflow.domain;
+
+import lombok.Getter;
+import org.bson.types.ObjectId;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.math.BigInteger;
+import java.util.Date;
+import java.util.Objects;
+
+@Getter
+public final class ProcessResourceId implements Comparable<ProcessResourceId>, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 5075333115382283359L;
+    private static final String CHAR_ARRAY = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    private static final BigInteger CHAR_ARRAY_LENGTH = BigInteger.valueOf(CHAR_ARRAY.length());
+    public static final String ID_SEPARATOR = "-";
+    public static final String NULL_SHORT_ID_VALUE = "NULL"; // TODO maybe value "TOTOK" should be more accurate
+
+    private ObjectId objectId;
+    private String shortProcessId;
+
+    public ProcessResourceId() {
+        this.objectId = new ObjectId();
+        this.shortProcessId = NULL_SHORT_ID_VALUE;
+    }
+
+    public ProcessResourceId(ObjectId processId) {
+        this.objectId = new ObjectId();
+        this.shortProcessId = generateShortProcessId(processId.toString());
+    }
+
+    public ProcessResourceId(String processId, String objectId) {
+        this.objectId = new ObjectId(objectId);
+        this.shortProcessId = generateShortProcessId(processId);
+    }
+
+    public ProcessResourceId(String processId, ObjectId objectId) {
+        this.objectId = objectId;
+        this.shortProcessId = generateShortProcessId(processId);
+    }
+
+    public ProcessResourceId(String compositeId) {
+        String[] parts = compositeId.split("-");
+        if (parts.length != 2) {
+            throw new IllegalArgumentException("Invalid composite ID format: " + compositeId);
+        }
+        this.shortProcessId = parts[0];
+        this.objectId = new ObjectId(parts[1]);
+    }
+
+    public String getFullId() {
+        return shortProcessId + ID_SEPARATOR + objectId.toHexString();
+    }
+
+    public String getStringId() {
+        return this.getFullId();
+    }
+
+    public Date getDate() {
+        return objectId.getDate();
+    }
+
+    public int getTimestamp() {
+        return objectId.getTimestamp();
+    }
+
+    @Override
+    public String toString() {
+        return getFullId();
+    }
+
+    private static String generateShortProcessId(String processId) {
+        if (processId == null || processId.isEmpty()) {
+            return null;
+        }
+        try {
+            BigInteger number = new BigInteger(processId, 16);
+            StringBuilder shortIdBuilder = new StringBuilder();
+
+            while (number.compareTo(BigInteger.ZERO) > 0) {
+                int remainder = number.mod(CHAR_ARRAY_LENGTH).intValue();
+                shortIdBuilder.append(CHAR_ARRAY.charAt(remainder));
+                number = number.divide(CHAR_ARRAY_LENGTH);
+            }
+
+            return shortIdBuilder.reverse().toString();
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid input string for encoding: " + processId, e);
+        }
+    }
+
+    private static String decodeShortProcessId(String shortProcessId) {
+        if (shortProcessId == null || shortProcessId.isEmpty()) {
+            return null;
+        }
+        BigInteger number = BigInteger.ZERO;
+        for (char c : shortProcessId.toCharArray()) {
+            number = number.multiply(CHAR_ARRAY_LENGTH);
+            int index = CHAR_ARRAY.indexOf(c);
+            if (index == -1) {
+                throw new IllegalArgumentException("Invalid character in short process ID: " + c);
+            }
+            number = number.add(BigInteger.valueOf(index));
+        }
+        return number.toString(16);
+    }
+
+    @Override
+    public int compareTo(ProcessResourceId other) {
+        return this.getFullId().compareTo(other.getFullId());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ProcessResourceId that = (ProcessResourceId) o;
+        return Objects.equals(objectId, that.objectId) && Objects.equals(shortProcessId, that.shortProcessId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(objectId, shortProcessId);
+    }
+
+}

--- a/src/main/java/com/netgrif/application/engine/workflow/domain/Task.java
+++ b/src/main/java/com/netgrif/application/engine/workflow/domain/Task.java
@@ -34,8 +34,7 @@ public class Task implements Serializable {
     private static final long serialVersionUID = -7112277728921547546L;
 
     @Id
-    @Builder.Default
-    private ObjectId _id = new ObjectId();
+    private ProcessResourceId _id = new ProcessResourceId();
 
     @Indexed
     @Getter
@@ -75,7 +74,7 @@ public class Task implements Serializable {
     @Setter
     private String userId;
 
-    @org.springframework.data.annotation.Transient
+    @Transient
     @Getter
     @Setter
     private IUser user;
@@ -200,7 +199,7 @@ public class Task implements Serializable {
     }
 
     @JsonIgnore
-    public ObjectId getObjectId() {
+    public ProcessResourceId getObjectId() {
         return _id;
     }
 
@@ -350,4 +349,58 @@ public class Task implements Serializable {
         TIME,
         MESSAGE,
     }
+
+    public static class TaskBuilder {
+
+        private ProcessResourceId _id;
+        private String processId;
+
+        private String caseId;
+        private String transitionId;
+        private TaskLayout layout;
+        private I18nString title;
+        private String caseColor;
+        private String caseTitle;
+        private Integer priority;
+        private String userId;
+        private IUser user;
+        private List triggers = new LinkedList<>();
+        private Map<String, Map<String, Boolean>> roles = new HashMap<>();
+        private Map<String, Map<String, Boolean>> userRefs = new HashMap<>();
+        private Map<String, Map<String, Boolean>> users = new HashMap<>();
+        private List viewRoles = new LinkedList<>();
+        private List viewUserRefs = new LinkedList<>();
+        private List viewUsers = new LinkedList<>();
+        private List negativeViewRoles = new LinkedList<>();
+        private List negativeViewUsers = new LinkedList<>();
+        private LocalDateTime startDate;
+        private LocalDateTime finishDate;
+        private String finishedBy;
+        private String transactionId;
+        private Boolean requiredFilled;
+        private LinkedHashSet immediateDataFields = new LinkedHashSet<>();
+        private List immediateData = new LinkedList<>();
+        private String icon;
+        private AssignPolicy assignPolicy = AssignPolicy.MANUAL;
+        private DataFocusPolicy dataFocusPolicy = DataFocusPolicy.MANUAL;
+        private FinishPolicy finishPolicy = FinishPolicy.MANUAL;
+        private Map<EventType, I18nString> eventTitles = new HashMap<>();
+        private Map<String, Boolean> assignedUserPolicy = new HashMap<>();
+        private Map<String, String> tags = new HashMap<>();
+
+        public TaskBuilder processId(String processId) {
+            this.processId = processId;
+            this._id = new ProcessResourceId(new ObjectId(processId));
+            return this;
+        }
+
+        public Task create() {
+            if (this._id == null && this.processId != null) {
+                this._id = new ProcessResourceId(new ObjectId(this.processId));
+            }
+            return new Task(_id, processId, caseId, transitionId, layout, title, caseColor, caseTitle, priority, userId, user, triggers, roles, userRefs, users, viewRoles, viewUserRefs, viewUsers, negativeViewRoles, negativeViewUsers, startDate, finishDate, finishedBy, transactionId, requiredFilled, immediateDataFields, immediateData, icon, assignPolicy, dataFocusPolicy, finishPolicy, eventTitles, assignedUserPolicy, new HashMap<>(), tags);
+        }
+
+    }
+
 }

--- a/src/main/java/com/netgrif/application/engine/workflow/domain/repositories/CaseRepository.java
+++ b/src/main/java/com/netgrif/application/engine/workflow/domain/repositories/CaseRepository.java
@@ -6,12 +6,14 @@ import org.bson.types.ObjectId;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.data.querydsl.binding.QuerydslBinderCustomizer;
 import org.springframework.data.querydsl.binding.QuerydslBindings;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface CaseRepository extends MongoRepository<Case, String>, QuerydslPredicateExecutor<Case>, QuerydslBinderCustomizer<QCase> {
@@ -20,11 +22,17 @@ public interface CaseRepository extends MongoRepository<Case, String>, QuerydslP
 
     List<Case> findAllBy_idIn(Iterable<String> id);
 
+    @Query("{ '_id.objectId': { $in: ?0 } }")
+    List<Case> findAllByObjectIdsIn(List<ObjectId> objectIds);
+
     Page<Case> findAllByUriNodeId(String uri, Pageable pageable);
 
     List<Case> findAllByPetriNetObjectId(ObjectId petriNetObjectId);
 
     void deleteAllByPetriNetObjectId(ObjectId petriNetObjectId);
+
+    @Query("{ '_id.objectId': ?0 }")
+    Optional<Case> findByIdObjectId(ObjectId objectId);
 
     @Override
     default void customize(QuerydslBindings bindings, QCase qCase) {

--- a/src/main/java/com/netgrif/application/engine/workflow/domain/repositories/TaskRepository.java
+++ b/src/main/java/com/netgrif/application/engine/workflow/domain/repositories/TaskRepository.java
@@ -2,15 +2,18 @@ package com.netgrif.application.engine.workflow.domain.repositories;
 
 import com.netgrif.application.engine.workflow.domain.QTask;
 import com.netgrif.application.engine.workflow.domain.Task;
+import org.bson.types.ObjectId;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.data.querydsl.binding.QuerydslBinderCustomizer;
 import org.springframework.data.querydsl.binding.QuerydslBindings;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 public interface TaskRepository extends MongoRepository<Task, String>, QuerydslPredicateExecutor<Task>, QuerydslBinderCustomizer<QTask> {
 
@@ -39,6 +42,9 @@ public interface TaskRepository extends MongoRepository<Task, String>, QuerydslP
     void deleteAllByCaseId(String caseId);
 
     void deleteAllByProcessId(String processId);
+
+    @Query("{ '_id.objectId': ?0 }")
+    Optional<Task> findByIdObjectId(ObjectId objectId);
 
     @Override
     default void customize(QuerydslBindings bindings, QTask qTask) {

--- a/src/main/java/com/netgrif/application/engine/workflow/service/CaseSearchService.java
+++ b/src/main/java/com/netgrif/application/engine/workflow/service/CaseSearchService.java
@@ -11,6 +11,7 @@ import com.netgrif.application.engine.petrinet.service.interfaces.IPetriNetServi
 import com.netgrif.application.engine.petrinet.web.responsebodies.PetriNetReference;
 import com.netgrif.application.engine.utils.FullPageRequest;
 import com.netgrif.application.engine.workflow.domain.Case;
+import com.netgrif.application.engine.workflow.domain.ProcessResourceId;
 import com.netgrif.application.engine.workflow.domain.QCase;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Expression;
@@ -344,7 +345,7 @@ public class CaseSearchService extends MongoSearchService<Case> {
     }
 
     private static BooleanExpression caseIdString(String caseId) {
-        return caseId.equals("") ? QCase.case$._id.isNull() : QCase.case$._id.eq(new ObjectId(caseId));
+        return caseId.equals("") ? QCase.case$._id.isNull() : QCase.case$._id.eq(new ProcessResourceId(caseId));
     }
 
     public Predicate group(Object query, LoggedUser user, Locale locale) {

--- a/src/main/java/com/netgrif/application/engine/workflow/service/TaskSearchService.java
+++ b/src/main/java/com/netgrif/application/engine/workflow/service/TaskSearchService.java
@@ -5,6 +5,7 @@ import com.netgrif.application.engine.petrinet.domain.PetriNetSearch;
 import com.netgrif.application.engine.petrinet.service.interfaces.IPetriNetService;
 import com.netgrif.application.engine.petrinet.web.responsebodies.PetriNetReference;
 import com.netgrif.application.engine.utils.FullPageRequest;
+import com.netgrif.application.engine.workflow.domain.ProcessResourceId;
 import com.netgrif.application.engine.workflow.domain.QTask;
 import com.netgrif.application.engine.workflow.domain.Task;
 import com.netgrif.application.engine.workflow.web.requestbodies.TaskSearchRequest;
@@ -149,7 +150,7 @@ public class TaskSearchService extends MongoSearchService<Task> {
     }
 
     public Predicate stringIdQuery(String id) {
-        return QTask.task._id.eq(new ObjectId(id));
+        return QTask.task._id.eq(new ProcessResourceId(id));
     }
 
     public Predicate userRefQuery(String userId) {

--- a/src/main/java/com/netgrif/application/engine/workflow/web/responsebodies/Task.java
+++ b/src/main/java/com/netgrif/application/engine/workflow/web/responsebodies/Task.java
@@ -6,6 +6,7 @@ import com.netgrif.application.engine.elastic.domain.ElasticTask;
 import com.netgrif.application.engine.petrinet.domain.dataset.Field;
 import com.netgrif.application.engine.petrinet.domain.events.EventType;
 import com.netgrif.application.engine.petrinet.domain.layout.TaskLayout;
+import com.netgrif.application.engine.workflow.domain.ProcessResourceId;
 import lombok.Data;
 import org.bson.types.ObjectId;
 
@@ -21,7 +22,7 @@ import java.util.Map;
 public class Task {
 
     @JsonIgnore
-    private ObjectId _id;
+    private ProcessResourceId _id;
 
     private String caseId;
 
@@ -106,7 +107,7 @@ public class Task {
     }
 
     public Task(ElasticTask entity) {
-        _id = new ObjectId(entity.getStringId());
+        _id = new ProcessResourceId(entity.getStringId());
         caseId = entity.getCaseId();
         transitionId = entity.getTransitionId();
         title = entity.getTitle();


### PR DESCRIPTION
# Description

Implements new id object ProcessResourceId that represents the id of an object that belongs to some process. The id is defined with two parts with the symbol '-' as a separator. The first part, prefix, is encoded Process (PetriNet) ObjectId named process short. The second part is an ObjectId that MongoDB generates and thus it is backwards compatible.

This definition of an id helps to identify to what process an object belongs to quickly. It is helpful in the process-resolving for NAE cluster.

Implements [NAE-1988]

## Dependencies

There are no dependencies on other PR

## How Has Been This Tested?

Manually tested and current tests refactored to match new id.

### Test Configuration

| Name                | Tested on |
|---------------------| --------- |
| OS                  |           Windows 11|
| Runtime             |           Java OpenJDK 21|
| Dependency Manager  |           Maven 3|
| Framework version   |           Spring Boot 3.2.5|
| Run parameters      |           |
| Other configuration |           |


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes have been checked, personally or remotely, with @machacjozef, @renczesstefan 
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes:
    - [ ] Lint test
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] I have checked my contribution with code analysis tools:
    - [ ] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_application-engine)
    - [ ] [Snyk](https://app.snyk.io/org/netgrif/project/ea82b3b8-658d-41f5-89a7-76cd600da01f)
- [ ] I have made corresponding changes to the documentation:
    - [ ] Developer documentation
    - [ ] User Guides
    - [ ] Migration Guides


[NAE-1988]: https://netgrif.atlassian.net/browse/NAE-1988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ