### PR TITLE
[NAE-2039] Search in workflow view 

### DIFF
--- a/src/main/java/com/netgrif/application/engine/elastic/service/ElasticPetriNetService.java
+++ b/src/main/java/com/netgrif/application/engine/elastic/service/ElasticPetriNetService.java
@@ -1,19 +1,39 @@
 package com.netgrif.application.engine.elastic.service;
 
+import com.netgrif.application.engine.auth.domain.LoggedUser;
 import com.netgrif.application.engine.elastic.domain.ElasticPetriNet;
 import com.netgrif.application.engine.elastic.domain.ElasticPetriNetRepository;
+
 import com.netgrif.application.engine.elastic.service.executors.Executor;
 import com.netgrif.application.engine.elastic.service.interfaces.IElasticPetriNetService;
 import com.netgrif.application.engine.petrinet.domain.PetriNet;
+import com.netgrif.application.engine.petrinet.domain.PetriNetSearch;
 import com.netgrif.application.engine.petrinet.service.interfaces.IPetriNetService;
+import com.netgrif.application.engine.petrinet.web.responsebodies.PetriNetReference;
+import com.netgrif.application.engine.utils.FullPageRequest;
 import lombok.extern.slf4j.Slf4j;
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.elasticsearch.core.ElasticsearchRestTemplate;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.data.elasticsearch.core.SearchHitSupport;
+import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
+import org.springframework.data.elasticsearch.core.query.NativeSearchQuery;
+import org.springframework.data.elasticsearch.core.query.NativeSearchQueryBuilder;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
+import java.util.*;
+import java.util.function.BinaryOperator;
 import java.util.stream.Collectors;
+
+import static org.elasticsearch.index.query.QueryBuilders.*;
 
 @Service
 @Slf4j
@@ -25,9 +45,15 @@ public class ElasticPetriNetService implements IElasticPetriNetService {
 
     private IPetriNetService petriNetService;
 
-    public ElasticPetriNetService(ElasticPetriNetRepository repository, Executor executors) {
+    private final ElasticsearchRestTemplate template;
+
+    @Value("${spring.data.elasticsearch.index.petrinet}")
+    protected String netIndex;
+
+    public ElasticPetriNetService(ElasticPetriNetRepository repository, Executor executors, ElasticsearchRestTemplate template) {
         this.repository = repository;
         this.executors = executors;
+        this.template = template;
     }
 
     @Lazy
@@ -88,5 +114,98 @@ public class ElasticPetriNetService implements IElasticPetriNetService {
     public List<PetriNet> findAllByUriNodeId(String uriNodeId) {
         List<ElasticPetriNet> elasticPetriNets = repository.findAllByUriNodeId(uriNodeId);
         return petriNetService.findAllById(elasticPetriNets.stream().map(ElasticPetriNet::getStringId).collect(Collectors.toList()));
+    }
+
+    @Override
+    public Page<PetriNetReference> search(PetriNetSearch requests, LoggedUser user, Pageable pageable, Locale locale, Boolean isIntersection) {
+        if (requests == null) {
+            throw new IllegalArgumentException("Request can not be null!");
+        }
+        log.debug("Searching for PetriNet query with logged user [{}]", user.getId());
+        LoggedUser loggedOrImpersonated = user.getSelfOrImpersonated();
+        NativeSearchQuery query = buildQuery(requests, loggedOrImpersonated, pageable, locale, isIntersection);
+        List<PetriNet> netPage;
+        long total;
+        if (query != null) {
+            SearchHits<ElasticPetriNet> hits = template.search(query, ElasticPetriNet.class, IndexCoordinates.of(netIndex));
+            Page<ElasticPetriNet> indexedNets = (Page) SearchHitSupport.unwrapSearchHits(SearchHitSupport.searchPageFor(hits, query.getPageable()));
+            netPage = petriNetService.findAllById(indexedNets.get().map(ElasticPetriNet::getStringId).collect(Collectors.toList()));
+            total = indexedNets.getTotalElements();
+            log.debug("Found [{}] total elements of page [{}]", netPage.size(), pageable.getPageNumber());
+        } else {
+            netPage = Collections.emptyList();
+            total = 0;
+        }
+
+        return new PageImpl<>(netPage.stream().map(net -> new PetriNetReference(net, locale)).collect(Collectors.toList()), pageable, total);
+    }
+
+    protected NativeSearchQuery buildQuery(PetriNetSearch request, LoggedUser user, Pageable pageable, Locale locale, Boolean isIntersection) {
+        List<BoolQueryBuilder> singleQueries = new LinkedList<>();
+        singleQueries.add(buildSingleQuery(request, user, locale));
+
+        if (isIntersection && !singleQueries.stream().allMatch(Objects::nonNull)) {
+            // one of the queries evaluates to empty set => the entire result is an empty set
+            return null;
+        } else if (!isIntersection) {
+            singleQueries = singleQueries.stream().filter(Objects::nonNull).collect(Collectors.toList());
+            if (singleQueries.size() == 0) {
+                // all queries result in an empty set => the entire result is an empty set
+                return null;
+            }
+        }
+
+        BinaryOperator<BoolQueryBuilder> reductionOperator = isIntersection ? BoolQueryBuilder::must : BoolQueryBuilder::should;
+        BoolQueryBuilder query = singleQueries.stream().reduce(new BoolQueryBuilder(), reductionOperator);
+
+        NativeSearchQueryBuilder builder = new NativeSearchQueryBuilder();
+        return builder
+                .withQuery(query)
+                .withPageable(pageable)
+                .build();
+    }
+
+    protected BoolQueryBuilder buildSingleQuery(PetriNetSearch request, LoggedUser user, Locale locale) {
+        BoolQueryBuilder query = boolQuery();
+
+        buildFullTextQuery(request, query);
+        // TODO: NAE-2039 check group
+        boolean resultAlwaysEmpty = buildGroupQuery(request, user, locale, query);
+        if (resultAlwaysEmpty) {
+            return null;
+        }
+        return query;
+    }
+
+    protected void buildFullTextQuery(PetriNetSearch request, BoolQueryBuilder query) {
+        if (request.getTitle() == null || request.getTitle().isEmpty()) {
+            return;
+        }
+
+        String searchText = "*" + request.getTitle() + "*";
+        Map<String, Float> fields = new HashMap<>();
+        fields.put("title.defaultValue", 2f);
+        fields.put("identifier", 1f);
+        QueryBuilder fullTextQuery = queryStringQuery(searchText).fields(fields);
+        query.must(fullTextQuery);
+    }
+
+    protected boolean buildGroupQuery(PetriNetSearch request, LoggedUser user, Locale locale, BoolQueryBuilder query) {
+        if (request.getGroup() == null || request.getGroup().isEmpty()) {
+            return false;
+        }
+
+        PetriNetSearch processQuery = new PetriNetSearch();
+        processQuery.setGroup(request.getGroup());
+        List<PetriNetReference> groupProcesses = this.petriNetService.search(processQuery, user, new FullPageRequest(), locale).getContent();
+        if (groupProcesses.size() == 0)
+            return true;
+
+        BoolQueryBuilder groupQuery = boolQuery();
+        groupProcesses.stream().map(PetriNetReference::getIdentifier)
+                .map(netIdentifier -> termQuery("identifier", netIdentifier))
+                .forEach(groupQuery::should);
+        query.filter(groupQuery);
+        return false;
     }
 }

--- a/src/main/java/com/netgrif/application/engine/elastic/service/ElasticPetriNetService.java
+++ b/src/main/java/com/netgrif/application/engine/elastic/service/ElasticPetriNetService.java
@@ -169,7 +169,6 @@ public class ElasticPetriNetService implements IElasticPetriNetService {
         BoolQueryBuilder query = boolQuery();
 
         buildFullTextQuery(request, query);
-        // TODO: NAE-2039 check group
         boolean resultAlwaysEmpty = buildGroupQuery(request, user, locale, query);
         if (resultAlwaysEmpty) {
             return null;

--- a/src/main/java/com/netgrif/application/engine/elastic/service/interfaces/IElasticPetriNetService.java
+++ b/src/main/java/com/netgrif/application/engine/elastic/service/interfaces/IElasticPetriNetService.java
@@ -1,10 +1,16 @@
 package com.netgrif.application.engine.elastic.service.interfaces;
 
+import com.netgrif.application.engine.auth.domain.LoggedUser;
 import com.netgrif.application.engine.elastic.domain.ElasticPetriNet;
 import com.netgrif.application.engine.petrinet.domain.PetriNet;
+import com.netgrif.application.engine.petrinet.domain.PetriNetSearch;
+import com.netgrif.application.engine.petrinet.web.responsebodies.PetriNetReference;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.scheduling.annotation.Async;
 
 import java.util.List;
+import java.util.Locale;
 
 public interface IElasticPetriNetService {
 
@@ -18,5 +24,7 @@ public interface IElasticPetriNetService {
     String findUriNodeId(PetriNet net);
 
     List<PetriNet> findAllByUriNodeId(String uriNodeId);
+
+    Page<PetriNetReference> search(PetriNetSearch requests, LoggedUser user, Pageable pageable, Locale locale, Boolean isIntersection);
 
 }


### PR DESCRIPTION

# Description
- implement basic elastic search for title and identifier to ElasticPetriNetService and implement endpoint for elastic search
- 
Implements [NAE-2039]

## Dependencies

none

### Third party dependencies

No new dependencies were introduced

### Blocking Pull requests

There are no dependencies on other PR

## How Has Been This Tested?

manually

### Test Configuration

<Please describe configuration for tests to run if applicable, like program parameters, host OS, VM configuration etc.>


| Name                | Tested on |
|---------------------| --------- |
| OS                  |     Linux Mint 22      |
| Runtime             |      Java 11.0.25      |
| Dependency Manager  |    maven 3.9.9    |
| Framework version   |    Spring Boot 2.7.18       |
| Run parameters      |           |
| Other configuration |           |


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes have been checked, personally or remotely, with @...
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have resolved all conflicts with the target branch of the PR
- [ ] I have updated and synced my code with the target branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes:
    - [ ] Lint test
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] I have checked my contribution with code analysis tools:
    - [ ] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_application-engine)
    - [ ] [Snyk](https://app.snyk.io/org/netgrif/project/ea82b3b8-658d-41f5-89a7-76cd600da01f)
- [ ] I have made corresponding changes to the documentation:
    - [ ] Developer documentation
    - [ ] User Guides
    - [ ] Migration Guides


[NAE-2039]: https://netgrif.atlassian.net/browse/NAE-2039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ