### PR TITLE
[NAE-2090]  Publish module services to actions

### DIFF
--- a/application-engine/.gitignore
+++ b/application-engine/.gitignore
@@ -143,3 +143,5 @@ log/
 /src/main/resources/certificates/private.der
 /src/main/resources/certificates/public.crt
 /modules/
+!src/main/java/**/modules
+!src/main/groovy/**/modules

--- a/application-engine/src/main/groovy/com/netgrif/application/engine/integration/modules/ModuleHolder.groovy
+++ b/application-engine/src/main/groovy/com/netgrif/application/engine/integration/modules/ModuleHolder.groovy
@@ -2,6 +2,6 @@ package com.netgrif.application.engine.integration.modules
 
 /**
  * A class where the module services are injected. The plugins are injected into metaclasses
- * */
+ */
 class ModuleHolder {
 }

--- a/application-engine/src/main/groovy/com/netgrif/application/engine/integration/modules/ModuleHolder.groovy
+++ b/application-engine/src/main/groovy/com/netgrif/application/engine/integration/modules/ModuleHolder.groovy
@@ -1,0 +1,7 @@
+package com.netgrif.application.engine.integration.modules
+
+/**
+ * A class where the module services are injected. The plugins are injected into metaclasses
+ * */
+class ModuleHolder {
+}

--- a/application-engine/src/main/groovy/com/netgrif/application/engine/integration/modules/ModuleServiceHolder.groovy
+++ b/application-engine/src/main/groovy/com/netgrif/application/engine/integration/modules/ModuleServiceHolder.groovy
@@ -1,0 +1,4 @@
+package com.netgrif.application.engine.integration.modules
+
+class ModuleServiceHolder {
+}

--- a/application-engine/src/main/groovy/com/netgrif/application/engine/integration/modules/ModuleServiceHolder.groovy
+++ b/application-engine/src/main/groovy/com/netgrif/application/engine/integration/modules/ModuleServiceHolder.groovy
@@ -1,4 +1,7 @@
 package com.netgrif.application.engine.integration.modules
 
+/**
+ * A class where the module services are injected for a named module. The plugins are injected into metaclasses
+ */
 class ModuleServiceHolder {
 }

--- a/application-engine/src/main/groovy/com/netgrif/application/engine/integration/modules/ModuleServiceInjector.groovy
+++ b/application-engine/src/main/groovy/com/netgrif/application/engine/integration/modules/ModuleServiceInjector.groovy
@@ -1,0 +1,30 @@
+package com.netgrif.application.engine.integration.modules
+
+import com.netgrif.application.engine.configuration.ApplicationContextProvider
+import com.netgrif.application.engine.startup.ApplicationEngineFinishRunner
+import com.netgrif.application.engine.startup.annotation.RunnerOrder
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.boot.ApplicationArguments
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+
+@Component
+@RunnerOrder(209)
+@ConditionalOnProperty(value = "nae.modules.services.enabled", havingValue = "true", matchIfMissing = true)
+class ModuleServiceInjector implements ApplicationEngineFinishRunner {
+
+    private static final Logger log = LoggerFactory.getLogger(ModuleServiceInjector.class)
+
+    @Override
+    void run(ApplicationArguments args) throws Exception {
+        def injectableBeans = ApplicationContextProvider.getAppContext().getBeansWithAnnotation(ModuleService.class)
+        if (!injectableBeans.isEmpty()) {
+            MetaClass holderMetaClass = ModuleHolder.metaClass
+            injectableBeans.forEach((key, value) -> {
+                log.debug("Injecting module service {} into action delegate make it available under module.{}", key, key)
+                holderMetaClass[key] = value
+            })
+        }
+    }
+}

--- a/application-engine/src/main/groovy/com/netgrif/application/engine/integration/modules/ModuleServiceInjector.groovy
+++ b/application-engine/src/main/groovy/com/netgrif/application/engine/integration/modules/ModuleServiceInjector.groovy
@@ -15,16 +15,47 @@ import org.springframework.stereotype.Component
 class ModuleServiceInjector implements ApplicationEngineFinishRunner {
 
     private static final Logger log = LoggerFactory.getLogger(ModuleServiceInjector.class)
+    private final String DEFAULT_KEY = "default"
 
     @Override
     void run(ApplicationArguments args) throws Exception {
         def injectableBeans = ApplicationContextProvider.getAppContext().getBeansWithAnnotation(ModuleService.class)
         if (!injectableBeans.isEmpty()) {
             MetaClass holderMetaClass = ModuleHolder.metaClass
-            injectableBeans.forEach((key, value) -> {
-                log.debug("Injecting module service {} into action delegate make it available under module.{}", key, key)
-                holderMetaClass[key] = value
-            })
+            def groupedServices = groupServicesByModule(injectableBeans)
+            groupedServices.each { entry ->
+                if (entry.key == DEFAULT_KEY) {
+                    entry.value.each { serviceEntry ->
+                        log.info("Injecting module service {} into action delegate making it available under module.{}", serviceEntry.key, serviceEntry.key)
+                        holderMetaClass[serviceEntry.key] = serviceEntry.value
+                    }
+                } else {
+                    MetaClass moduleServiceHolderMetaClass = ModuleServiceHolder.metaClass
+                    entry.value.each { serviceEntry ->
+                        log.info("Injecting module service {} into module holder {} into action delegate making it available under module.{}.{}", serviceEntry.key, entry.key, entry.key, serviceEntry.key)
+                        moduleServiceHolderMetaClass[serviceEntry.key] = serviceEntry.value
+                    }
+                    holderMetaClass[entry.key] = new ModuleServiceHolder()
+                }
+            }
         }
     }
+
+    private Map<String, Map<String, Object>> groupServicesByModule(Map<String, Object> services) {
+        Map<String, Map<String, Object>> grouped = [(DEFAULT_KEY): [:]]
+        services.each { entry ->
+            ModuleService[] annotations = entry.value.getClass().getAnnotationsByType(ModuleService.class)
+            if (annotations.length == 0) throw new IllegalStateException("Module Service bean must have @ModuleService annotations")
+            ModuleService annotation = annotations[0]
+            if (annotation.value().isBlank()) {
+                grouped[(DEFAULT_KEY)].put(entry.key, entry.value)
+            } else {
+                String moduleName = annotation.value()
+                if (!grouped.containsKey(moduleName)) grouped.put(moduleName, [:])
+                grouped[moduleName].put(entry.key, entry.value)
+            }
+        }
+        return grouped
+    }
+
 }

--- a/application-engine/src/main/groovy/com/netgrif/application/engine/integration/modules/ModuleServiceInjector.groovy
+++ b/application-engine/src/main/groovy/com/netgrif/application/engine/integration/modules/ModuleServiceInjector.groovy
@@ -9,6 +9,16 @@ import org.springframework.boot.ApplicationArguments
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
 
+/**
+ * Component responsible for injecting module services into the application runtime.
+ * This class implements {@link ApplicationEngineFinishRunner} to perform the injection
+ * after the application finishes its startup routine. The services are grouped by modules
+ * and made available for runtime action delegation.
+ *
+ * The execution of this class is controlled by properties defined in the application configuration.
+ * By default, it is enabled and executed in the specified order.
+ */
+
 @Component
 @RunnerOrder(209)
 @ConditionalOnProperty(value = "nae.modules.services.enabled", havingValue = "true", matchIfMissing = true)
@@ -16,6 +26,16 @@ class ModuleServiceInjector implements ApplicationEngineFinishRunner {
 
     private static final Logger log = LoggerFactory.getLogger(ModuleServiceInjector.class)
     private final String DEFAULT_KEY = "default"
+
+    /**
+     * Executes the injection of services annotated with {@code @ModuleService}.
+     * This method collects all beans marked with the {@code @ModuleService} annotation,
+     * groups them by their associated module, and injects them into the respective meta-classes
+     * (e.g., {@code ModuleHolder} and {@code ModuleServiceHolder}).
+     *
+     * @param args application arguments passed during startup
+     * @throws Exception if any error occurs during the injection process
+     */
 
     @Override
     void run(ApplicationArguments args) throws Exception {
@@ -40,6 +60,17 @@ class ModuleServiceInjector implements ApplicationEngineFinishRunner {
             }
         }
     }
+
+    /**
+     * Groups services annotated with {@code @ModuleService} by their associated module.
+     * Each service is categorized under a module key specified by the annotation's value.
+     * Services without a specified module are grouped under the "default" key.
+     *
+     * @param services a map of service names to service instances retrieved from the application context
+     * @return a map where each key represents a module, and the value is another map containing
+     *         services (name and instance) associated with that module
+     * @throws IllegalStateException if any service lacks the {@code @ModuleService} annotation
+     */
 
     private Map<String, Map<String, Object>> groupServicesByModule(Map<String, Object> services) {
         Map<String, Map<String, Object>> grouped = [(DEFAULT_KEY): [:]]

--- a/application-engine/src/main/groovy/com/netgrif/application/engine/petrinet/domain/dataset/logic/action/ActionDelegate.groovy
+++ b/application-engine/src/main/groovy/com/netgrif/application/engine/petrinet/domain/dataset/logic/action/ActionDelegate.groovy
@@ -2,6 +2,7 @@ package com.netgrif.application.engine.petrinet.domain.dataset.logic.action
 
 import com.netgrif.application.engine.auth.service.GroupService
 import com.netgrif.application.engine.auth.service.UserService
+import com.netgrif.application.engine.integration.modules.ModuleHolder
 import com.netgrif.application.engine.petrinet.service.interfaces.IPetriNetService
 import com.netgrif.application.engine.adapter.spring.petrinet.service.ProcessRoleService
 import com.netgrif.application.engine.adapter.spring.workflow.domain.QCase
@@ -200,6 +201,8 @@ class ActionDelegate {
 
     PluginHolder Plugin
 
+    ModuleHolder Module
+
     /**
      * Reference of case and task in which current action is taking place.
      */
@@ -222,6 +225,7 @@ class ActionDelegate {
         this.outcomes = new ArrayList<>()
         this.Frontend = new FrontendActionOutcome(this.useCase, this.task, this.outcomes)
         this.Plugin = new PluginHolder()
+        this.Module = new ModuleHolder()
     }
 
     def initFieldsMap(Map<String, String> fieldIds) {

--- a/application-engine/src/main/java/com/netgrif/application/engine/integration/modules/ModuleService.java
+++ b/application-engine/src/main/java/com/netgrif/application/engine/integration/modules/ModuleService.java
@@ -1,0 +1,9 @@
+package com.netgrif.application.engine.integration.modules;
+
+import java.lang.annotation.*;
+
+@Documented
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ModuleService {
+}

--- a/application-engine/src/main/java/com/netgrif/application/engine/integration/modules/ModuleService.java
+++ b/application-engine/src/main/java/com/netgrif/application/engine/integration/modules/ModuleService.java
@@ -1,9 +1,18 @@
 package com.netgrif.application.engine.integration.modules;
 
+import org.springframework.core.annotation.AliasFor;
+
 import java.lang.annotation.*;
 
 @Documented
 @Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ModuleService {
+
+    @AliasFor("module")
+    String value() default "";
+
+    @AliasFor("value")
+    String module() default "";
+
 }


### PR DESCRIPTION
# Description

Implementing an option for modules to annotate spring services as Module Service to publish the service into the Action delegate to be accessible from process actions.

Implements [NAE-2090]

## Dependencies

There are no dependencies on other PR

## How Has Been This Tested?

Manually tested with a simple module that was annotated, and loaded with the engine.

### Test Configuration

| Name                | Tested on |
|---------------------| --------- |
| OS                  |         Linux (ArchLinux)  |
| Runtime             |       Java 21 (OpenJDK)    |
| Dependency Manager  |       Maven 3    |
| Framework version   |       Spring 3.4.4    |
| Run parameters      |       -Dloader.debug=true    |
| Other configuration |     maven.project.profile=dev      |


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My changes have been checked, personally or remotely, with @...
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes:
    - [ ] Lint test
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] I have checked my contribution with code analysis tools:
    - [ ] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_application-engine)
    - [ ] [Snyk](https://app.snyk.io/org/netgrif/project/ea82b3b8-658d-41f5-89a7-76cd600da01f)
- [x] I have made corresponding changes to the documentation:
    - [x] Developer documentation
    - [ ] User Guides
    - [ ] Migration Guides
