### PR TITLE
[NAE-2099] MenuItemService.appendChildCaseIdInDataSet not setting hasChildren correctly

### DIFF
--- a/src/main/java/com/netgrif/application/engine/menu/services/MenuItemService.java
+++ b/src/main/java/com/netgrif/application/engine/menu/services/MenuItemService.java
@@ -351,7 +351,7 @@ public class MenuItemService implements IMenuItemService {
         dataSet.put(MenuItemConstants.FIELD_DUPLICATE_TITLE, Map.of("type", FieldType.I18N.getName(), "value",
                 new I18nString("")));
         dataSet.put(MenuItemConstants.FIELD_DUPLICATE_IDENTIFIER, Map.of("type", FieldType.TEXT.getName(),
-                "value",""));
+                "value", ""));
         dataSet.put(MenuItemConstants.FIELD_MENU_NAME, Map.of("type", FieldType.I18N.getName(),
                 "value", newTitle));
         dataSet.put(MenuItemConstants.FIELD_TAB_NAME, Map.of("type", FieldType.I18N.getName(),
@@ -520,7 +520,7 @@ public class MenuItemService implements IMenuItemService {
     protected Case handleFilter(Case filterCase, FilterBody body) throws TransitionNotExecutableException {
         if (mustCreateFilter(filterCase, body)) {
             return createFilter(body);
-        } else if (mustUpdateFilter(filterCase, body)){
+        } else if (mustUpdateFilter(filterCase, body)) {
             return updateFilter(filterCase, body);
         } else {
             return filterCase;
@@ -600,6 +600,7 @@ public class MenuItemService implements IMenuItemService {
     protected Case getOrCreateFolderRecursive(UriNode node, MenuItemBody body) throws TransitionNotExecutableException {
         return getOrCreateFolderRecursive(node, body, null);
     }
+
     protected Case getOrCreateFolderRecursive(UriNode node, MenuItemBody body, Case childFolderCase) throws TransitionNotExecutableException {
         IUser loggedUser = userService.getLoggedOrSystem();
         Case folderCase = findFolderCase(node);
@@ -636,15 +637,15 @@ public class MenuItemService implements IMenuItemService {
     protected void appendChildCaseIdInDataSet(Case folderCase, String childItemCaseId, Map<String, Map<String, Object>> dataSet) {
         List<String> childIds = MenuItemUtils.getCaseIdsFromCaseRef(folderCase, MenuItemConstants.FIELD_CHILD_ITEM_IDS);
         if (childIds == null || childIds.isEmpty()) {
-            dataSet.put(MenuItemConstants.FIELD_CHILD_ITEM_IDS, Map.of("type", FieldType.CASE_REF.getName(),
-                    "value", List.of(childItemCaseId)));
+            childIds = List.of(childItemCaseId);
         } else {
             childIds.add(childItemCaseId);
-            dataSet.put(MenuItemConstants.FIELD_CHILD_ITEM_IDS, Map.of("type", FieldType.CASE_REF.getName(),
-                    "value", childIds));
         }
+
+        dataSet.put(MenuItemConstants.FIELD_CHILD_ITEM_IDS, Map.of("type", FieldType.CASE_REF.getName(),
+                "value", childIds));
         dataSet.put(MenuItemConstants.FIELD_HAS_CHILDREN, Map.of("type", FieldType.BOOLEAN.getName(),
-                "value", MenuItemUtils.hasFolderChildren(folderCase)));
+                "value", !childIds.isEmpty()));
     }
 
     protected void appendChildCaseIdInMemory(Case folderCase, String childItemCaseId) {
@@ -673,7 +674,7 @@ public class MenuItemService implements IMenuItemService {
     }
 
     protected Case createCase(String identifier, String title, LoggedUser loggedUser) {
-        return workflowService.createCaseByIdentifier(identifier, title, "",loggedUser).getCase();
+        return workflowService.createCaseByIdentifier(identifier, title, "", loggedUser).getCase();
     }
 
     protected Case setData(Case useCase, String transId, Map<String, Map<String, Object>> dataSet) {


### PR DESCRIPTION
# Description
Fixes the condition for setting the field hasChildren correctly. Added condition to check if newValue is not empty.

Fixes [NAE-2099]

## Dependencies

No new dependencies were introduced

### Third party dependencies

No new dependencies were introduced

### Blocking Pull requests

There are no dependencies on other PR

## How Has Been This Tested?

Manually on an already existing project.

### Test Configuration


| Name                | Tested on |
|---------------------| --------- |
| OS                  | Windows 11  |
| Runtime             |  Oracle OpenJDK 11.0.25   |
| Dependency Manager  |  Maven 3.9.9   |
| Framework version   |   Spring Boot 2.7.18   |
| Run parameters      |           |
| Other configuration |           |


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My changes have been checked, personally or remotely, with @...
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes:
    - [x] Lint test
    - [x] Unit tests
    - [x] Integration tests
- [x] I have checked my contribution with code analysis tools:
    - [x] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_application-engine)
    - [x] [Snyk](https://app.snyk.io/org/netgrif/project/ea82b3b8-658d-41f5-89a7-76cd600da01f)
- [ ] I have made corresponding changes to the documentation:
    - [ ] Developer documentation
    - [ ] User Guides
    - [ ] Migration Guides


[NAE-2099]: https://netgrif.atlassian.net/browse/NAE-2099?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ