### PR TITLE
[NAE-2171] Removing expired unactivated invited users" throws NullPointerException

### DIFF
--- a/application-engine/src/main/java/com/netgrif/application/engine/auth/service/RegistrationService.java
+++ b/application-engine/src/main/java/com/netgrif/application/engine/auth/service/RegistrationService.java
@@ -13,6 +13,7 @@ import com.netgrif.application.engine.objects.auth.domain.AbstractUser;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -31,7 +32,6 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Slf4j
-@Service
 public class RegistrationService implements IRegistrationService {
 
     @Autowired

--- a/application-engine/src/main/java/com/netgrif/application/engine/configuration/ImplBasedBeanConfiguration.java
+++ b/application-engine/src/main/java/com/netgrif/application/engine/configuration/ImplBasedBeanConfiguration.java
@@ -1,0 +1,17 @@
+package com.netgrif.application.engine.configuration;
+
+import com.netgrif.application.engine.auth.service.RegistrationService;
+import com.netgrif.application.engine.auth.service.interfaces.IRegistrationService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ImplBasedBeanConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean(IRegistrationService.class)
+    public IRegistrationService registrationService() {
+        return new RegistrationService();
+    }
+}


### PR DESCRIPTION
# Description

Unexpected behaviour when there is null for realm ID, and it is not resolved explicitly.

Fixes [NAE-2171]

## Dependencies

No new dependencies were introduced

### Third party dependencies

No new dependencies were introduced

### Blocking Pull requests

There are no dependencies on other PR

## How Has Been This Tested?

This was tested manually.

### Test Configuration

| Name                | Tested on            |
| ------------------- | -------------------- |
| OS                  | macOS Sequoia 15.3.1 |
| Runtime             | Java 21              |
| Dependency Manager  | Maven 3.9.9n         |
| Framework version   | Spring Boot 3.2.5    |
| Run parameters      |                      |
| Other configuration |                      |


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes have been checked, personally or remotely, with @machacjozef 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes:
    - [x] Lint test
    - [x] Unit tests
    - [x] Integration tests
- [ ] I have checked my contribution with code analysis tools:
    - [ ] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_application-engine)
    - [ ] [Snyk](https://app.snyk.io/org/netgrif/project/ea82b3b8-658d-41f5-89a7-76cd600da01f)
- [ ] I have made corresponding changes to the documentation:
    - [ ] Developer documentation
    - [ ] User Guides
    - [ ] Migration Guides
