### PR TITLE
NAE-2212 - added method that will cache all petriNets functions

### DIFF
--- a/application-engine/src/main/java/com/netgrif/application/engine/workflow/service/FieldActionsCacheService.java
+++ b/application-engine/src/main/java/com/netgrif/application/engine/workflow/service/FieldActionsCacheService.java
@@ -15,6 +15,8 @@ import groovy.lang.GroovyShell;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -22,6 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Service
 @Slf4j
@@ -30,14 +33,15 @@ public class FieldActionsCacheService implements IFieldActionsCacheService {
     private final RunnerConfigurationProperties.FieldRunnerProperties properties;
 
     private IPetriNetService petriNetService;
-
+    private MongoTemplate mongoTemplate;
     private Map<String, Closure> actionsCache;
     private Map<String, List<CachedFunction>> namespaceFunctionsCache;
     private Map<String, CachedFunction> functionsCache;
     private final GroovyShell shell;
 
-    public FieldActionsCacheService(RunnerConfigurationProperties.FieldRunnerProperties properties, IGroovyShellFactory shellFactory) {
+    public FieldActionsCacheService(RunnerConfigurationProperties.FieldRunnerProperties properties, IGroovyShellFactory shellFactory, MongoTemplate mongoTemplate) {
         this.properties = properties;
+        this.mongoTemplate = mongoTemplate;
         this.actionsCache = new MaxSizeHashMap<>(properties.getActionCacheSize());
         this.functionsCache = new MaxSizeHashMap<>(properties.getFunctionsCacheSize());
         this.namespaceFunctionsCache = new MaxSizeHashMap<>(properties.getNamespaceCacheSize());
@@ -94,6 +98,21 @@ public class FieldActionsCacheService implements IFieldActionsCacheService {
             cachedFunctions.add(functionsCache.get(function.getStringId()));
         });
         return cachedFunctions;
+    }
+
+    @Override
+    public void cacheAllPetriNetsFunctions() {
+        Query query = new Query().cursorBatchSize(500);
+        try (Stream<PetriNet> stream = mongoTemplate.query(PetriNet.class).matching(query).stream()) {
+            stream.forEach(petriNet -> {
+                if (petriNet == null) return;
+                try {
+                    this.cachePetriNetFunctions(petriNet);
+                } catch (Exception e) {
+                    log.warn("Failed to cache functions for PetriNet id={}", petriNet.getStringId(), e);
+                }
+            });
+        }
     }
 
     @Override

--- a/application-engine/src/main/java/com/netgrif/application/engine/workflow/service/interfaces/IFieldActionsCacheService.java
+++ b/application-engine/src/main/java/com/netgrif/application/engine/workflow/service/interfaces/IFieldActionsCacheService.java
@@ -27,5 +27,7 @@ public interface IFieldActionsCacheService {
 
     void clearNamespaceFunctionCache();
 
+    void cacheAllPetriNetsFunctions();
+
     void clearFunctionCache();
 }


### PR DESCRIPTION
# Description

This PR introduces a function that caches all petriNets namespace functions in cache.

Implements [https://netgrif.atlassian.net/browse/NAE-2182]

## How Has Been This Tested?

The functionality was tested in local cluster with admin and 1 worker.

| Name                | Tested on |
|---------------------| --------- |
| OS                  |     Windows 11      |
| Runtime             |      Java 21     |
| Dependency Manager  |     Apache Maven 3.9.9  |
| Framework version   |      Spring Boot 3.2.5, NAE 7.0.0-rev7    |
| Run parameters      |       mvn clean install    |
| Other configuration |           |


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My changes have been checked, personally or remotely, with @...
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes:
    - [ ] Lint test
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] I have checked my contribution with code analysis tools:
    - [ ] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_application-engine)
    - [ ] [Snyk](https://app.snyk.io/org/netgrif/project/ea82b3b8-658d-41f5-89a7-76cd600da01f)
- [ ] I have made corresponding changes to the documentation:
    - [ ] Developer documentation
    - [ ] User Guides
    - [ ] Migration Guides