### PR TITLE
[NAE-2460] PFQL placeholder support

### DIFF
--- a/src/main/java/com/netgrif/application/engine/pfql/domain/antlr4/QueryLang.g4
+++ b/src/main/java/com/netgrif/application/engine/pfql/domain/antlr4/QueryLang.g4
@@ -228,12 +228,12 @@ tasksUserIdComparison: tasksUserId SPACE stringComparison # tasksUserIdBasic
                      ;
 
 // basic comparisons
-objectIdComparison: (NOT SPACE?)? op=(EQ | NEQ) SPACE STRING ;
-stringComparison: (NOT SPACE?)? op=(EQ | NEQ | CONTAINS | LT | GT | LTE | GTE) SPACE STRING ;
+objectIdComparison: (NOT SPACE?)? op=(EQ | NEQ) SPACE (STRING | LOGGED_USER_ID) ;
+stringComparison: (NOT SPACE?)? op=(EQ | NEQ | CONTAINS | LT | GT | LTE | GTE) SPACE (STRING | loggedUserStringAttribute) ;
 numberComparison: (NOT SPACE?)? op=(EQ | NEQ | LT | GT | LTE | GTE) SPACE number=(INT | DOUBLE) ;
 dateComparison: (NOT SPACE?)? op=(EQ | NEQ | LT | GT | LTE | GTE) SPACE DATE ;
 dateTimeComparison: (NOT SPACE?)? op=(EQ | NEQ | LT | GT | LTE | GTE) SPACE DATETIME ;
-booleanComparison: (NOT SPACE?)? op=(EQ | NEQ) SPACE BOOLEAN ;
+booleanComparison: (NOT SPACE?)? op=(EQ | NEQ) SPACE (BOOLEAN | LOGGED_USER_ANONYMOUS) ;
 
 // in list/in range comparisons
 inListStringComparison: (NOT SPACE?)? op=IN SPACE? stringList ;
@@ -326,13 +326,13 @@ ASC: A S C ;
 DESC: D E S C ;
 
 // basic types
-stringList: '(' SPACE? (STRING SPACE? (',' SPACE? STRING SPACE? )* )? SPACE? ')' ;
+stringList: '(' SPACE? ((STRING | loggedUserStringAttribute) SPACE? (',' SPACE? (STRING | loggedUserStringAttribute) SPACE? )* )? SPACE? ')' ;
 intList: '(' SPACE? (INT SPACE? (',' SPACE? INT SPACE? )* )? SPACE? ')' ;
 doubleList: '(' SPACE? (DOUBLE SPACE? (',' SPACE? DOUBLE SPACE? )* )? SPACE? ')' ;
 dateList: '(' SPACE? (DATE SPACE? (',' SPACE? DATE SPACE? )* )? SPACE? ')' ;
 dateTimeList: '(' SPACE? (DATETIME SPACE? (',' SPACE? DATETIME SPACE? )* )? SPACE? ')' ;
 versionList: '(' SPACE? (VERSION_NUMBER SPACE? (',' SPACE? VERSION_NUMBER SPACE? )* )? SPACE? ')' ;
-stringRange: leftEndpoint=('(' | '[') SPACE? STRING SPACE? ':' SPACE? STRING SPACE? rightEndpoint=(')' | ']') ;
+stringRange: leftEndpoint=('(' | '[') SPACE? (STRING | loggedUserStringAttribute) SPACE? ':' SPACE? (STRING | loggedUserStringAttribute) SPACE? rightEndpoint=(')' | ']') ;
 intRange: leftEndpoint=('(' | '[') SPACE? INT SPACE? ':' SPACE? INT SPACE? rightEndpoint=(')' | ']') ;
 doubleRange: leftEndpoint=('(' | '[') SPACE? DOUBLE SPACE? ':' SPACE? DOUBLE SPACE? rightEndpoint=(')' | ']') ;
 dateRange: leftEndpoint=('(' | '[') SPACE? DATE SPACE? ':' SPACE? DATE SPACE? rightEndpoint=(')' | ']') ;
@@ -349,6 +349,13 @@ JAVA_ID: [a-zA-Z$_] [a-zA-Z0-9$_]* ;
 
 SPACE: [ ]+ ;
 ANY: . ;
+
+// place holders
+loggedUserStringAttribute: (LOGGED_USER_ID | LOGGED_USER_USERNAME | LOGGED_USER_FULLNAME);
+LOGGED_USER_ID: L O G G E D U S E R '.' I D ;
+LOGGED_USER_FULLNAME:  L O G G E D U S E R '.' F U L L N A M E ;
+LOGGED_USER_USERNAME:  L O G G E D U S E R '.' U S E R N A M E ;
+LOGGED_USER_ANONYMOUS: L O G G E D U S E R '.' A N O N Y M O U S ;
 
 // fragments
 fragment A : [aA];

--- a/src/main/java/com/netgrif/application/engine/pfql/domain/antlr4/QueryLang.g4
+++ b/src/main/java/com/netgrif/application/engine/pfql/domain/antlr4/QueryLang.g4
@@ -98,6 +98,7 @@ userAttribute: ID
              ;
 
 // resource comparisons
+// todo: authorComparison for process?
 processComparisons: idComparison
                   | identifierComparison
                   | versionComparison

--- a/src/main/java/com/netgrif/application/engine/pfql/service/QueryLangEvaluator.java
+++ b/src/main/java/com/netgrif/application/engine/pfql/service/QueryLangEvaluator.java
@@ -1,6 +1,8 @@
 package com.netgrif.application.engine.pfql.service;
 
+import com.netgrif.application.engine.auth.domain.LoggedUser;
 import com.netgrif.application.engine.auth.domain.QUser;
+import com.netgrif.application.engine.auth.service.interfaces.IUserService;
 import com.netgrif.application.engine.petrinet.domain.QPetriNet;
 import com.netgrif.application.engine.pfql.domain.antlr4.QueryLangBaseListener;
 import com.netgrif.application.engine.pfql.domain.antlr4.QueryLangParser;
@@ -23,6 +25,7 @@ import org.bson.types.QObjectId;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.util.Pair;
 
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
@@ -37,6 +40,8 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
 
     private final ParseTreeProperty<String> elasticQuery = new ParseTreeProperty<>();
     private final ParseTreeProperty<Predicate> mongoQuery = new ParseTreeProperty<>();
+
+    private final IUserService userService;
 
     @Getter
     private QueryType resourceType;
@@ -56,6 +61,10 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
     private int pageNumber = 0;
     private int pageSize = 20;
     private final List<Sort.Order> sortOrders = new ArrayList<>();
+
+    public QueryLangEvaluator(IUserService userService) {
+        this.userService = userService;
+    }
 
     public void setElasticQuery(ParseTree node, String query) {
         elasticQuery.put(node, query);
@@ -134,6 +143,107 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
 
         setMongoQuery(current, predicate);
         setElasticQuery(current, elasticQuery);
+    }
+
+    private String handleStringComparisonWithPlaceholders(QueryLangParser.StringComparisonContext ctx) {
+        if (ctx.STRING() != null) {
+            return getStringValue(ctx.STRING().getText());
+        }
+
+        if (ctx.loggedUserStringAttribute() != null) {
+            return handleLoggedUserStringAttribute(ctx.loggedUserStringAttribute());
+        }
+
+        throw new IllegalArgumentException("Wrong or missing query value on string comparison");
+    }
+
+    private ObjectId handleObjectIdComparisonWithPlaceholders(QueryLangParser.ObjectIdComparisonContext ctx) {
+        if (ctx.STRING() != null) {
+            return getObjectIdValue(ctx.STRING().getText());
+        }
+        if (ctx.LOGGED_USER_ID() != null) {
+            LoggedUser loggedUser = this.userService.getLoggedOrSystem().transformToLoggedUser();
+            return getObjectIdValue(loggedUser.getId());
+        }
+
+        throw new IllegalArgumentException("Wrong or missing query value on object id comparison");
+    }
+
+    private List<String> handleStringListComparison(QueryLangParser.StringListContext ctx) {
+        List<String> result = new ArrayList<>();
+
+        if (ctx.STRING() != null && !ctx.STRING().isEmpty()) {
+            result.addAll(ctx.STRING().stream()
+                    .map(node -> getStringValue(node.getText()))
+                    .collect(Collectors.toList()));
+        }
+        if (ctx.loggedUserStringAttribute() != null && !ctx.loggedUserStringAttribute().isEmpty()) {
+            result.addAll(ctx.loggedUserStringAttribute().stream()
+                    .map(this::handleLoggedUserStringAttribute)
+                    .collect(Collectors.toList()));
+        }
+
+        return result;
+    }
+
+    private List<ObjectId> handleObjectIdListComparison(QueryLangParser.StringListContext ctx) {
+        List<ObjectId> result = new ArrayList<>();
+
+        if (ctx.STRING() != null && !ctx.STRING().isEmpty()) {
+            result.addAll(ctx.STRING().stream()
+                    .map(node -> getObjectIdValue(node.getText()))
+                    .collect(Collectors.toList()));
+        }
+        if (ctx.loggedUserStringAttribute() != null && !ctx.loggedUserStringAttribute().isEmpty()) {
+            LoggedUser loggedUser = this.userService.getLoggedOrSystem().transformToLoggedUser();
+            result.add(getObjectIdValue(loggedUser.getId()));
+        }
+
+        return result;
+    }
+
+    private String handleLoggedUserStringAttribute(QueryLangParser.LoggedUserStringAttributeContext ctx) {
+        LoggedUser loggedUser = this.userService.getLoggedOrSystem().transformToLoggedUser();
+        if (ctx.LOGGED_USER_ID() != null) {
+            return loggedUser.getId();
+        }
+        if (ctx.LOGGED_USER_USERNAME() != null) {
+            return loggedUser.getUsername();
+        }
+        if (ctx.LOGGED_USER_FULLNAME() != null) {
+            return loggedUser.getFullName();
+        }
+        return "";
+    }
+
+    /// returns pair, where the first element is left value and the second element is right value
+    private Pair<String, String> handleInRangeStringComparison(QueryLangParser.StringRangeContext ctx) {
+        String left = "", right = "";
+
+        if (ctx.STRING(0) != null) {
+            left = getStringValue(ctx.STRING(0).getText());
+        } else if (ctx.loggedUserStringAttribute(0) != null) {
+            left = ctx.loggedUserStringAttribute(0).getText();
+        }
+        if (ctx.STRING(1) != null) {
+            right = getStringValue(ctx.STRING(1).getText());
+        } else if (ctx.loggedUserStringAttribute(1) != null) {
+            right = ctx.loggedUserStringAttribute(1).getText();
+        }
+
+        return Pair.of(left, right);
+    }
+
+    private String handleBooleanComparison(QueryLangParser.BooleanComparisonContext ctx) {
+        if (ctx.BOOLEAN() != null) {
+            return ctx.BOOLEAN().getText();
+        }
+        if (ctx.LOGGED_USER_ANONYMOUS() != null) {
+            LoggedUser loggedUser = this.userService.getLoggedOrSystem().transformToLoggedUser();
+            return String.valueOf(loggedUser.isAnonymous());
+        }
+
+        throw new IllegalArgumentException("Wrong or missing query value on boolean comparison");
     }
 
     private Predicate getEmptyMongoQuery() {
@@ -399,7 +509,7 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
         Token op = ctx.objectIdComparison().op;
         boolean not = ctx.objectIdComparison().NOT() != null;
         checkOp(ComparisonType.ID, op);
-        ObjectId objectId = getObjectIdValue(ctx.objectIdComparison().STRING().getText());
+        ObjectId objectId = handleObjectIdComparisonWithPlaceholders(ctx.objectIdComparison());
 
         switch (resourceType) {
             case PROCESS:
@@ -428,12 +538,6 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
         Token op = ctx.inListStringComparison().op;
         boolean not = ctx.inListStringComparison().NOT() != null;
         checkOp(ComparisonType.ID, op);
-        List<ObjectId> objectIdList = ctx.inListStringComparison().stringList().STRING().stream()
-                .map(node -> getObjectIdValue(node.getText()))
-                .collect(Collectors.toList());
-        List<String> stringIdList = ctx.inListStringComparison().stringList().STRING().stream()
-                .map(node -> getStringValue(node.getText()))
-                .collect(Collectors.toList());
 
         switch (resourceType) {
             case PROCESS:
@@ -441,6 +545,7 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
                 break;
             case CASE:
                 qObjectId = QCase.case$._id;
+                List<String> stringIdList = handleStringListComparison(ctx.inListStringComparison().stringList());
                 setElasticQuery(ctx, buildElasticQueryInList("stringId", stringIdList, not));
                 break;
             case TASK:
@@ -453,6 +558,7 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
                 throw new IllegalArgumentException("Unknown query type: " + resourceType);
         }
 
+        List<ObjectId> objectIdList = handleObjectIdListComparison(ctx.inListStringComparison().stringList());
         setMongoQuery(ctx, buildObjectIdPredicateInList(qObjectId, objectIdList, not));
     }
 
@@ -461,7 +567,7 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
         StringPath stringPath;
         Token op = ctx.stringComparison().op;
         boolean not = ctx.stringComparison().NOT() != null;
-        String string = getStringValue(ctx.stringComparison().STRING().getText());
+        String string = handleStringComparisonWithPlaceholders(ctx.stringComparison());
 
         switch (resourceType) {
             case PROCESS:
@@ -485,7 +591,7 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
     public void exitTitleList(QueryLangParser.TitleListContext ctx) {
         StringPath stringPath;
         boolean not = ctx.inListStringComparison().NOT() != null;
-        List<String> stringList = ctx.inListStringComparison().stringList().STRING().stream().map(node -> getStringValue(node.getText())).collect(Collectors.toList());
+        List<String> stringList = handleStringListComparison(ctx.inListStringComparison().stringList());
 
         switch (resourceType) {
             case PROCESS:
@@ -511,8 +617,7 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
         boolean not = ctx.inRangeStringComparison().NOT() != null;
         boolean leftEndpointOpen = ctx.inRangeStringComparison().stringRange().leftEndpoint.getText().equals(LEFT_OPEN_ENDPOINT);
         boolean rightEndpointOpen = ctx.inRangeStringComparison().stringRange().rightEndpoint.getText().equals(RIGHT_OPEN_ENDPOINT);
-        String leftString = getStringValue(ctx.inRangeStringComparison().stringRange().STRING(0).getText());
-        String rightString = getStringValue(ctx.inRangeStringComparison().stringRange().STRING(1).getText());
+        Pair<String, String> leftAndRightStrings = handleInRangeStringComparison(ctx.inRangeStringComparison().stringRange());
 
         switch (resourceType) {
             case PROCESS:
@@ -520,7 +625,8 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
                 break;
             case CASE:
                 stringPath = QCase.case$.title;
-                setElasticQuery(ctx, buildElasticQueryInRange("title", leftString, leftEndpointOpen, rightString, rightEndpointOpen, not));
+                setElasticQuery(ctx, buildElasticQueryInRange("title", leftAndRightStrings.getFirst(),
+                        leftEndpointOpen, leftAndRightStrings.getSecond(), rightEndpointOpen, not));
                 break;
             case TASK:
                 stringPath = QTask.task.title.defaultValue;
@@ -529,7 +635,8 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
                 throw new IllegalArgumentException("Unknown query type: " + resourceType);
         }
 
-        setMongoQuery(ctx, buildStringPredicateInRange(stringPath, leftString, leftEndpointOpen, rightString, rightEndpointOpen, not));
+        setMongoQuery(ctx, buildStringPredicateInRange(stringPath, leftAndRightStrings.getFirst(), leftEndpointOpen,
+                leftAndRightStrings.getSecond(), rightEndpointOpen, not));
     }
 
     @Override
@@ -537,7 +644,7 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
         StringPath stringPath = QPetriNet.petriNet.identifier;
         Token op = ctx.stringComparison().op;
         boolean not = ctx.stringComparison().NOT() != null;
-        String string = getStringValue(ctx.stringComparison().STRING().getText());
+        String string = handleStringComparisonWithPlaceholders(ctx.stringComparison());
 
         setMongoQuery(ctx, buildStringPredicate(stringPath, op.getType(), string, not));
     }
@@ -546,7 +653,7 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
     public void exitIdentifierList(QueryLangParser.IdentifierListContext ctx) {
         StringPath stringPath = QPetriNet.petriNet.identifier;
         boolean not = ctx.inListStringComparison().NOT() != null;
-        List<String> stringList = ctx.inListStringComparison().stringList().STRING().stream().map(node -> getStringValue(node.getText())).collect(Collectors.toList());
+        List<String> stringList = handleStringListComparison(ctx.inListStringComparison().stringList());
 
         setMongoQuery(ctx, buildStringPredicateInList(stringPath, stringList, not));
     }
@@ -557,10 +664,10 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
         boolean not = ctx.inRangeStringComparison().NOT() != null;
         boolean leftEndpointOpen = ctx.inRangeStringComparison().stringRange().leftEndpoint.getText().equals(LEFT_OPEN_ENDPOINT);
         boolean rightEndpointOpen = ctx.inRangeStringComparison().stringRange().rightEndpoint.getText().equals(RIGHT_OPEN_ENDPOINT);
-        String leftString = getStringValue(ctx.inRangeStringComparison().stringRange().STRING(0).getText());
-        String rightString = getStringValue(ctx.inRangeStringComparison().stringRange().STRING(1).getText());
+        Pair<String, String> leftAndRightStrings = handleInRangeStringComparison(ctx.inRangeStringComparison().stringRange());
 
-        setMongoQuery(ctx, buildStringPredicateInRange(stringPath, leftString, leftEndpointOpen, rightString, rightEndpointOpen, not));
+        setMongoQuery(ctx, buildStringPredicateInRange(stringPath, leftAndRightStrings.getFirst(), leftEndpointOpen,
+                leftAndRightStrings.getSecond(), rightEndpointOpen, not));
     }
 
     @Override
@@ -702,7 +809,7 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
         StringPath stringPath = QTask.task.processId;
         Token op = ctx.stringComparison().op;
         boolean not = ctx.stringComparison().NOT() != null;
-        String string = getStringValue(ctx.stringComparison().STRING().getText());
+        String string = handleStringComparisonWithPlaceholders(ctx.stringComparison());
 
         setMongoQuery(ctx, buildStringPredicate(stringPath, op.getType(), string, not));
     }
@@ -711,9 +818,7 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
     public void exitProcessIdList(QueryLangParser.ProcessIdListContext ctx) {
         StringPath stringPath = QTask.task.processId;
         boolean not = ctx.inListStringComparison().NOT() != null;
-        List<String> stringList = ctx.inListStringComparison().stringList().STRING().stream()
-                .map(node -> getStringValue(node.getText()))
-                .collect(Collectors.toList());
+        List<String> stringList = handleStringListComparison(ctx.inListStringComparison().stringList());
 
         setMongoQuery(ctx, buildStringPredicateInList(stringPath, stringList, not));
     }
@@ -723,7 +828,7 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
         QObjectId qObjectId = QCase.case$.petriNetObjectId;
         Token op = ctx.objectIdComparison().op;
         boolean not = ctx.objectIdComparison().NOT() != null;
-        ObjectId objectId = getObjectIdValue(ctx.objectIdComparison().STRING().getText());
+        ObjectId objectId = handleObjectIdComparisonWithPlaceholders(ctx.objectIdComparison());
 
         setMongoQuery(ctx, buildObjectIdPredicate(qObjectId, op.getType(), objectId, not));
         setElasticQuery(ctx, buildElasticQuery("processId", op.getType(), objectId.toString(), not));
@@ -733,12 +838,8 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
     public void exitProcessIdObjIdList(QueryLangParser.ProcessIdObjIdListContext ctx) {
         QObjectId qObjectId = QCase.case$.petriNetObjectId;
         boolean not = ctx.inListStringComparison().NOT() != null;
-        List<ObjectId> objectIdList = ctx.inListStringComparison().stringList().STRING().stream()
-                .map(node -> getObjectIdValue(node.getText()))
-                .collect(Collectors.toList());
-        List<String> stringList = ctx.inListStringComparison().stringList().STRING().stream()
-                .map(node -> getStringValue(node.getText()))
-                .collect(Collectors.toList());
+        List<ObjectId> objectIdList = handleObjectIdListComparison(ctx.inListStringComparison().stringList());
+        List<String> stringList = handleStringListComparison(ctx.inListStringComparison().stringList());
 
         setMongoQuery(ctx, buildObjectIdPredicateInList(qObjectId, objectIdList, not));
         setElasticQuery(ctx, buildElasticQueryInList("processId", stringList, not));
@@ -749,7 +850,7 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
         StringPath stringPath = QCase.case$.processIdentifier;
         Token op = ctx.stringComparison().op;
         boolean not = ctx.stringComparison().NOT() != null;
-        String string = getStringValue(ctx.stringComparison().STRING().getText());
+        String string = handleStringComparisonWithPlaceholders(ctx.stringComparison());
 
         setMongoQuery(ctx, buildStringPredicate(stringPath, op.getType(), string, not));
         setElasticQuery(ctx, buildElasticQuery("processIdentifier", op.getType(), string, not));
@@ -759,7 +860,7 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
     public void exitProcessIdentifierList(QueryLangParser.ProcessIdentifierListContext ctx) {
         StringPath stringPath = QCase.case$.processIdentifier;
         boolean not = ctx.inListStringComparison().NOT() != null;
-        List<String> stringList = ctx.inListStringComparison().stringList().STRING().stream().map(node -> getStringValue(node.getText())).collect(Collectors.toList());
+        List<String> stringList = handleStringListComparison(ctx.inListStringComparison().stringList());
 
         setMongoQuery(ctx, buildStringPredicateInList(stringPath, stringList, not));
         setElasticQuery(ctx, buildElasticQueryInList("processIdentifier", stringList, not));
@@ -771,11 +872,12 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
         boolean not = ctx.inRangeStringComparison().NOT() != null;
         boolean leftEndpointOpen = ctx.inRangeStringComparison().stringRange().leftEndpoint.getText().equals(LEFT_OPEN_ENDPOINT);
         boolean rightEndpointOpen = ctx.inRangeStringComparison().stringRange().rightEndpoint.getText().equals(RIGHT_OPEN_ENDPOINT);
-        String leftString = getStringValue(ctx.inRangeStringComparison().stringRange().STRING(0).getText());
-        String rightString = getStringValue(ctx.inRangeStringComparison().stringRange().STRING(1).getText());
+        Pair<String, String> leftAndRightStrings = handleInRangeStringComparison(ctx.inRangeStringComparison().stringRange());
 
-        setMongoQuery(ctx, buildStringPredicateInRange(stringPath, leftString, leftEndpointOpen, rightString, rightEndpointOpen, not));
-        setElasticQuery(ctx, buildElasticQueryInRange("processIdentifier", leftString, leftEndpointOpen, rightString, rightEndpointOpen, not));
+        setMongoQuery(ctx, buildStringPredicateInRange(stringPath, leftAndRightStrings.getFirst(), leftEndpointOpen,
+                leftAndRightStrings.getSecond(), rightEndpointOpen, not));
+        setElasticQuery(ctx, buildElasticQueryInRange("processIdentifier", leftAndRightStrings.getFirst(),
+                leftEndpointOpen, leftAndRightStrings.getSecond(), rightEndpointOpen, not));
     }
 
     @Override
@@ -783,7 +885,7 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
         StringPath stringPath = QCase.case$.author.id;
         Token op = ctx.stringComparison().op;
         boolean not = ctx.stringComparison().NOT() != null;
-        String string = getStringValue(ctx.stringComparison().STRING().getText());
+        String string = handleStringComparisonWithPlaceholders(ctx.stringComparison());
 
         setMongoQuery(ctx, buildStringPredicate(stringPath, op.getType(), string, not));
         setElasticQuery(ctx, buildElasticQuery("author", op.getType(), string, not));
@@ -793,9 +895,7 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
     public void exitAuthorList(QueryLangParser.AuthorListContext ctx) {
         StringPath stringPath = QCase.case$.author.id;
         boolean not = ctx.inListStringComparison().NOT() != null;
-        List<String> stringList = ctx.inListStringComparison().stringList().STRING().stream()
-                .map(node -> getStringValue(node.getText()))
-                .collect(Collectors.toList());
+        List<String> stringList = handleStringListComparison(ctx.inListStringComparison().stringList());
 
         setMongoQuery(ctx, buildStringPredicateInList(stringPath, stringList, not));
         setElasticQuery(ctx, buildElasticQueryInList("author", stringList, not));
@@ -806,7 +906,7 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
         StringPath stringPath = QTask.task.transitionId;
         Token op = ctx.stringComparison().op;
         boolean not = ctx.stringComparison().NOT() != null;
-        String string = getStringValue(ctx.stringComparison().STRING().getText());
+        String string = handleStringComparisonWithPlaceholders(ctx.stringComparison());
 
         setMongoQuery(ctx, buildStringPredicate(stringPath, op.getType(), string, not));
     }
@@ -815,7 +915,7 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
     public void exitTransitionIdList(QueryLangParser.TransitionIdListContext ctx) {
         StringPath stringPath = QTask.task.transitionId;
         boolean not = ctx.inListStringComparison().NOT() != null;
-        List<String> stringList = ctx.inListStringComparison().stringList().STRING().stream().map(node -> getStringValue(node.getText())).collect(Collectors.toList());
+        List<String> stringList = handleStringListComparison(ctx.inListStringComparison().stringList());
 
         setMongoQuery(ctx, buildStringPredicateInList(stringPath, stringList, not));
     }
@@ -826,10 +926,10 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
         boolean not = ctx.inRangeStringComparison().NOT() != null;
         boolean leftEndpointOpen = ctx.inRangeStringComparison().stringRange().leftEndpoint.getText().equals(LEFT_OPEN_ENDPOINT);
         boolean rightEndpointOpen = ctx.inRangeStringComparison().stringRange().rightEndpoint.getText().equals(RIGHT_OPEN_ENDPOINT);
-        String leftString = getStringValue(ctx.inRangeStringComparison().stringRange().STRING(0).getText());
-        String rightString = getStringValue(ctx.inRangeStringComparison().stringRange().STRING(1).getText());
+        Pair<String, String> leftAndRightStrings = handleInRangeStringComparison(ctx.inRangeStringComparison().stringRange());
 
-        setMongoQuery(ctx, buildStringPredicateInRange(stringPath, leftString, leftEndpointOpen, rightString, rightEndpointOpen, not));
+        setMongoQuery(ctx, buildStringPredicateInRange(stringPath, leftAndRightStrings.getFirst(), leftEndpointOpen,
+                leftAndRightStrings.getSecond(), rightEndpointOpen, not));
     }
 
     @Override
@@ -850,7 +950,7 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
         StringPath stringPath = QTask.task.userId;
         Token op = ctx.stringComparison().op;
         boolean not = ctx.stringComparison().NOT() != null;
-        String string = getStringValue(ctx.stringComparison().STRING().getText());
+        String string = handleStringComparisonWithPlaceholders(ctx.stringComparison());
 
         setMongoQuery(ctx, buildStringPredicate(stringPath, op.getType(), string, not));
     }
@@ -859,9 +959,7 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
     public void exitUserIdList(QueryLangParser.UserIdListContext ctx) {
         StringPath stringPath = QTask.task.userId;
         boolean not = ctx.inListStringComparison().NOT() != null;
-        List<String> stringList = ctx.inListStringComparison().stringList().STRING().stream()
-                .map(node -> getStringValue(node.getText()))
-                .collect(Collectors.toList());
+        List<String> stringList = handleStringListComparison(ctx.inListStringComparison().stringList());
 
         setMongoQuery(ctx, buildStringPredicateInList(stringPath, stringList, not));
     }
@@ -871,7 +969,7 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
         StringPath stringPath = QTask.task.caseId;
         Token op = ctx.stringComparison().op;
         boolean not = ctx.stringComparison().NOT() != null;
-        String string = getStringValue(ctx.stringComparison().STRING().getText());
+        String string = handleStringComparisonWithPlaceholders(ctx.stringComparison());
 
         setMongoQuery(ctx, buildStringPredicate(stringPath, op.getType(), string, not));
     }
@@ -880,9 +978,7 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
     public void exitCaseIdList(QueryLangParser.CaseIdListContext ctx) {
         StringPath stringPath = QTask.task.caseId;
         boolean not = ctx.inListStringComparison().NOT() != null;
-        List<String> stringList = ctx.inListStringComparison().stringList().STRING().stream()
-                .map(node -> getStringValue(node.getText()))
-                .collect(Collectors.toList());
+        List<String> stringList = handleStringListComparison(ctx.inListStringComparison().stringList());
 
         setMongoQuery(ctx, buildStringPredicateInList(stringPath, stringList, not));
     }
@@ -1006,7 +1102,7 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
         StringPath stringPath = QUser.user.name;
         Token op = ctx.stringComparison().op;
         boolean not = ctx.stringComparison().NOT() != null;
-        String string = getStringValue(ctx.stringComparison().STRING().getText());
+        String string = handleStringComparisonWithPlaceholders(ctx.stringComparison());
 
         setMongoQuery(ctx, buildStringPredicate(stringPath, op.getType(), string, not));
     }
@@ -1015,7 +1111,7 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
     public void exitNameList(QueryLangParser.NameListContext ctx) {
         StringPath stringPath = QUser.user.name;
         boolean not = ctx.inListStringComparison().NOT() != null;
-        List<String> stringList = ctx.inListStringComparison().stringList().STRING().stream().map(node -> getStringValue(node.getText())).collect(Collectors.toList());
+        List<String> stringList = handleStringListComparison(ctx.inListStringComparison().stringList());
 
         setMongoQuery(ctx, buildStringPredicateInList(stringPath, stringList, not));
     }
@@ -1026,10 +1122,10 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
         boolean not = ctx.inRangeStringComparison().NOT() != null;
         boolean leftEndpointOpen = ctx.inRangeStringComparison().stringRange().leftEndpoint.getText().equals(LEFT_OPEN_ENDPOINT);
         boolean rightEndpointOpen = ctx.inRangeStringComparison().stringRange().rightEndpoint.getText().equals(RIGHT_OPEN_ENDPOINT);
-        String leftString = getStringValue(ctx.inRangeStringComparison().stringRange().STRING(0).getText());
-        String rightString = getStringValue(ctx.inRangeStringComparison().stringRange().STRING(1).getText());
+        Pair<String, String> leftAndRightStrings = handleInRangeStringComparison(ctx.inRangeStringComparison().stringRange());
 
-        setMongoQuery(ctx, buildStringPredicateInRange(stringPath, leftString, leftEndpointOpen, rightString, rightEndpointOpen, not));
+        setMongoQuery(ctx, buildStringPredicateInRange(stringPath, leftAndRightStrings.getFirst(), leftEndpointOpen,
+                leftAndRightStrings.getSecond(), rightEndpointOpen, not));
     }
 
     @Override
@@ -1037,7 +1133,7 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
         StringPath stringPath = QUser.user.surname;
         Token op = ctx.stringComparison().op;
         boolean not = ctx.stringComparison().NOT() != null;
-        String string = getStringValue(ctx.stringComparison().STRING().getText());
+        String string = handleStringComparisonWithPlaceholders(ctx.stringComparison());
 
         setMongoQuery(ctx, buildStringPredicate(stringPath, op.getType(), string, not));
     }
@@ -1046,7 +1142,7 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
     public void exitSurnameList(QueryLangParser.SurnameListContext ctx) {
         StringPath stringPath = QUser.user.surname;
         boolean not = ctx.inListStringComparison().NOT() != null;
-        List<String> stringList = ctx.inListStringComparison().stringList().STRING().stream().map(node -> getStringValue(node.getText())).collect(Collectors.toList());
+        List<String> stringList = handleStringListComparison(ctx.inListStringComparison().stringList());
 
         setMongoQuery(ctx, buildStringPredicateInList(stringPath, stringList, not));
     }
@@ -1057,10 +1153,10 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
         boolean not = ctx.inRangeStringComparison().NOT() != null;
         boolean leftEndpointOpen = ctx.inRangeStringComparison().stringRange().leftEndpoint.getText().equals(LEFT_OPEN_ENDPOINT);
         boolean rightEndpointOpen = ctx.inRangeStringComparison().stringRange().rightEndpoint.getText().equals(RIGHT_OPEN_ENDPOINT);
-        String leftString = getStringValue(ctx.inRangeStringComparison().stringRange().STRING(0).getText());
-        String rightString = getStringValue(ctx.inRangeStringComparison().stringRange().STRING(1).getText());
+        Pair<String, String> leftAndRightStrings = handleInRangeStringComparison(ctx.inRangeStringComparison().stringRange());
 
-        setMongoQuery(ctx, buildStringPredicateInRange(stringPath, leftString, leftEndpointOpen, rightString, rightEndpointOpen, not));
+        setMongoQuery(ctx, buildStringPredicateInRange(stringPath, leftAndRightStrings.getFirst(), leftEndpointOpen,
+                leftAndRightStrings.getSecond(), rightEndpointOpen, not));
     }
 
     @Override
@@ -1068,7 +1164,7 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
         StringPath stringPath = QUser.user.email;
         Token op = ctx.stringComparison().op;
         boolean not = ctx.stringComparison().NOT() != null;
-        String string = getStringValue(ctx.stringComparison().STRING().getText());
+        String string = handleStringComparisonWithPlaceholders(ctx.stringComparison());
 
         setMongoQuery(ctx, buildStringPredicate(stringPath, op.getType(), string, not));
     }
@@ -1077,7 +1173,7 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
     public void exitEmailList(QueryLangParser.EmailListContext ctx) {
         StringPath stringPath = QUser.user.email;
         boolean not = ctx.inListStringComparison().NOT() != null;
-        List<String> stringList = ctx.inListStringComparison().stringList().STRING().stream().map(node -> getStringValue(node.getText())).collect(Collectors.toList());
+        List<String> stringList = handleStringListComparison(ctx.inListStringComparison().stringList());
 
         setMongoQuery(ctx, buildStringPredicateInList(stringPath, stringList, not));
     }
@@ -1088,10 +1184,10 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
         boolean not = ctx.inRangeStringComparison().NOT() != null;
         boolean leftEndpointOpen = ctx.inRangeStringComparison().stringRange().leftEndpoint.getText().equals(LEFT_OPEN_ENDPOINT);
         boolean rightEndpointOpen = ctx.inRangeStringComparison().stringRange().rightEndpoint.getText().equals(RIGHT_OPEN_ENDPOINT);
-        String leftString = getStringValue(ctx.inRangeStringComparison().stringRange().STRING(0).getText());
-        String rightString = getStringValue(ctx.inRangeStringComparison().stringRange().STRING(1).getText());
+        Pair<String, String> leftAndRightStrings = handleInRangeStringComparison(ctx.inRangeStringComparison().stringRange());
 
-        setMongoQuery(ctx, buildStringPredicateInRange(stringPath, leftString, leftEndpointOpen, rightString, rightEndpointOpen, not));
+        setMongoQuery(ctx, buildStringPredicateInRange(stringPath, leftAndRightStrings.getFirst(), leftEndpointOpen,
+                leftAndRightStrings.getSecond(), rightEndpointOpen, not));
     }
 
     @Override
@@ -1100,7 +1196,7 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
         Token op = ctx.stringComparison().op;
         checkOp(ComparisonType.STRING, op);
         boolean not = ctx.stringComparison().NOT() != null;
-        String string = getStringValue(ctx.stringComparison().STRING().getText());
+        String string = handleStringComparisonWithPlaceholders(ctx.stringComparison());
 
         setMongoQuery(ctx, null);
         setElasticQuery(ctx, buildElasticQuery("dataSet." + fieldId + ".textValue", op.getType(), string, not));
@@ -1111,7 +1207,7 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
     public void exitDataStringList(QueryLangParser.DataStringListContext ctx) {
         String fieldId = ctx.dataValue().fieldId.getText();
         boolean not = ctx.inListStringComparison().NOT() != null;
-        List<String> stringList = ctx.inListStringComparison().stringList().STRING().stream().map(node -> getStringValue(node.getText())).collect(Collectors.toList());
+        List<String> stringList = handleStringListComparison(ctx.inListStringComparison().stringList());
 
         setMongoQuery(ctx, null);
         setElasticQuery(ctx, buildElasticQueryInList("dataSet." + fieldId + ".textValue", stringList, not));
@@ -1124,11 +1220,11 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
         boolean not = ctx.inRangeStringComparison().NOT() != null;
         boolean leftEndpointOpen = ctx.inRangeStringComparison().stringRange().leftEndpoint.getText().equals(LEFT_OPEN_ENDPOINT);
         boolean rightEndpointOpen = ctx.inRangeStringComparison().stringRange().rightEndpoint.getText().equals(RIGHT_OPEN_ENDPOINT);
-        String leftString = getStringValue(ctx.inRangeStringComparison().stringRange().STRING(0).getText());
-        String rightString = getStringValue(ctx.inRangeStringComparison().stringRange().STRING(1).getText());
+        Pair<String, String> leftAndRightStrings = handleInRangeStringComparison(ctx.inRangeStringComparison().stringRange());
 
         setMongoQuery(ctx, null);
-        setElasticQuery(ctx, buildElasticQueryInRange("dataSet." + fieldId + ".textValue", leftString, leftEndpointOpen, rightString, rightEndpointOpen, not));
+        setElasticQuery(ctx, buildElasticQueryInRange("dataSet." + fieldId + ".textValue", leftAndRightStrings.getFirst(),
+                leftEndpointOpen, leftAndRightStrings.getSecond(), rightEndpointOpen, not));
         this.searchWithElastic = true;
     }
 
@@ -1254,7 +1350,7 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
         Token op = ctx.booleanComparison().op;
         checkOp(ComparisonType.BOOLEAN, op);
         boolean not = ctx.booleanComparison().NOT() != null;
-        String booleanValue = ctx.booleanComparison().BOOLEAN().getText();
+        String booleanValue = handleBooleanComparison(ctx.booleanComparison());
 
         setMongoQuery(ctx, null);
         setElasticQuery(ctx, buildElasticQuery("dataSet." + fieldId + ".booleanValue", op.getType(), booleanValue, not));
@@ -1267,7 +1363,7 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
         Token op = ctx.stringComparison().op;
         checkOp(ComparisonType.STRING, op);
         boolean not = ctx.stringComparison().NOT() != null;
-        String string = getStringValue(ctx.stringComparison().STRING().getText());
+        String string = handleStringComparisonWithPlaceholders(ctx.stringComparison());
 
         setMongoQuery(ctx, null);
         setElasticQuery(ctx, buildElasticQuery("dataSet." + fieldId + ".options", op.getType(), string, not));
@@ -1278,7 +1374,7 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
     public void exitDataOptionsList(QueryLangParser.DataOptionsListContext ctx) {
         String fieldId = ctx.dataOptions().fieldId.getText();
         boolean not = ctx.inListStringComparison().NOT() != null;
-        List<String> stringList = ctx.inListStringComparison().stringList().STRING().stream().map(node -> getStringValue(node.getText())).collect(Collectors.toList());
+        List<String> stringList = handleStringListComparison(ctx.inListStringComparison().stringList());
 
         setMongoQuery(ctx, null);
         setElasticQuery(ctx, buildElasticQueryInList("dataSet." + fieldId + ".options", stringList, not));
@@ -1291,11 +1387,11 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
         boolean not = ctx.inRangeStringComparison().NOT() != null;
         boolean leftEndpointOpen = ctx.inRangeStringComparison().stringRange().leftEndpoint.getText().equals(LEFT_OPEN_ENDPOINT);
         boolean rightEndpointOpen = ctx.inRangeStringComparison().stringRange().rightEndpoint.getText().equals(RIGHT_OPEN_ENDPOINT);
-        String leftString = getStringValue(ctx.inRangeStringComparison().stringRange().STRING(0).getText());
-        String rightString = getStringValue(ctx.inRangeStringComparison().stringRange().STRING(1).getText());
+        Pair<String, String> leftAndRightStrings = handleInRangeStringComparison(ctx.inRangeStringComparison().stringRange());
 
         setMongoQuery(ctx, null);
-        setElasticQuery(ctx, buildElasticQueryInRange("dataSet." + fieldId + ".options", leftString, leftEndpointOpen, rightString, rightEndpointOpen, not));
+        setElasticQuery(ctx, buildElasticQueryInRange("dataSet." + fieldId + ".options", leftAndRightStrings.getFirst(),
+                leftEndpointOpen, leftAndRightStrings.getSecond(), rightEndpointOpen, not));
         this.searchWithElastic = true;
     }
 
@@ -1369,7 +1465,7 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
         Token op = ctx.stringComparison().op;
         checkOp(ComparisonType.STRING, op);
         boolean not = ctx.stringComparison().NOT() != null;
-        String string = getStringValue(ctx.stringComparison().STRING().getText());
+        String string = handleStringComparisonWithPlaceholders(ctx.stringComparison());
 
         setMongoQuery(ctx, null);
         setElasticQuery(ctx, buildElasticQuery("tasks." + taskId + ".userId", op.getType(), string, not));
@@ -1380,9 +1476,7 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
     public void exitTasksUserIdList(QueryLangParser.TasksUserIdListContext ctx) {
         String taskId = ctx.tasksUserId().taskId.getText();
         boolean not = ctx.inListStringComparison().NOT() != null;
-        List<String> stringList = ctx.inListStringComparison().stringList().STRING().stream()
-                .map(node -> getStringValue(node.getText()))
-                .collect(Collectors.toList());
+        List<String> stringList = handleStringListComparison(ctx.inListStringComparison().stringList());
 
         setMongoQuery(ctx, null);
         setElasticQuery(ctx, buildElasticQueryInList("tasks." + taskId + ".userId", stringList, not));

--- a/src/main/java/com/netgrif/application/engine/pfql/service/QueryLangEvaluator.java
+++ b/src/main/java/com/netgrif/application/engine/pfql/service/QueryLangEvaluator.java
@@ -222,17 +222,29 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
 
     /// returns pair, where the first element is left value and the second element is right value
     private Pair<String, String> handleInRangeStringComparison(QueryLangParser.StringRangeContext ctx) {
-        String left = "", right = "";
+        List<ParseTree> filteredChildren = ctx.children.stream()
+                .filter(node -> node instanceof TerminalNode && ((TerminalNode) node).getSymbol().getType() == QueryLangParser.STRING
+                        || node instanceof QueryLangParser.LoggedUserStringAttributeContext)
+                .collect(Collectors.toList());
 
-        if (ctx.STRING(0) != null) {
-            left = getStringValue(ctx.STRING(0).getText());
-        } else if (ctx.loggedUserStringAttribute(0) != null) {
-            left = ctx.loggedUserStringAttribute(0).getText();
+        if (filteredChildren.size() < 2) {
+            throw new IllegalArgumentException("Wrong in range values");
         }
-        if (ctx.STRING(1) != null) {
-            right = getStringValue(ctx.STRING(1).getText());
-        } else if (ctx.loggedUserStringAttribute(1) != null) {
-            right = ctx.loggedUserStringAttribute(1).getText();
+
+        String left;
+        ParseTree leftNode = filteredChildren.get(0);
+        if (leftNode instanceof TerminalNode) {
+            left = getStringValue(leftNode.getText());
+        } else {
+            left = handleLoggedUserStringAttribute((QueryLangParser.LoggedUserStringAttributeContext) leftNode);
+        }
+
+        String right;
+        ParseTree rightNode = filteredChildren.get(1);
+        if (rightNode instanceof TerminalNode) {
+            right = getStringValue(rightNode.getText());
+        } else {
+            right = handleLoggedUserStringAttribute((QueryLangParser.LoggedUserStringAttributeContext) rightNode);
         }
 
         return Pair.of(left, right);

--- a/src/main/java/com/netgrif/application/engine/pfql/service/QueryLangEvaluator.java
+++ b/src/main/java/com/netgrif/application/engine/pfql/service/QueryLangEvaluator.java
@@ -1215,7 +1215,11 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
         String string = handleStringComparisonWithPlaceholders(ctx.stringComparison());
 
         setMongoQuery(ctx, null);
-        setElasticQuery(ctx, buildElasticQuery("dataSet." + fieldId + ".textValue", op.getType(), string, not));
+        String attribute = "dataSet." + fieldId + ".fulltextValue";
+        if (op.getType() == QueryLangParser.EQ || op.getType() == QueryLangParser.NEQ) {
+            attribute += ".keyword";
+        }
+        setElasticQuery(ctx, buildElasticQuery(attribute, op.getType(), string, not));
         this.searchWithElastic = true;
     }
 
@@ -1226,7 +1230,7 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
         List<String> stringList = handleStringListComparison(ctx.inListStringComparison().stringList());
 
         setMongoQuery(ctx, null);
-        setElasticQuery(ctx, buildElasticQueryInList("dataSet." + fieldId + ".textValue", stringList, not));
+        setElasticQuery(ctx, buildElasticQueryInList("dataSet." + fieldId + ".fulltextValue", stringList, not));
         this.searchWithElastic = true;
     }
 
@@ -1239,7 +1243,7 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
         Pair<String, String> leftAndRightStrings = handleInRangeStringComparison(ctx.inRangeStringComparison().stringRange());
 
         setMongoQuery(ctx, null);
-        setElasticQuery(ctx, buildElasticQueryInRange("dataSet." + fieldId + ".textValue", leftAndRightStrings.getFirst(),
+        setElasticQuery(ctx, buildElasticQueryInRange("dataSet." + fieldId + ".fulltextValue", leftAndRightStrings.getFirst(),
                 leftEndpointOpen, leftAndRightStrings.getSecond(), rightEndpointOpen, not));
         this.searchWithElastic = true;
     }

--- a/src/main/java/com/netgrif/application/engine/pfql/service/QueryLangEvaluator.java
+++ b/src/main/java/com/netgrif/application/engine/pfql/service/QueryLangEvaluator.java
@@ -195,8 +195,12 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
                     .collect(Collectors.toList()));
         }
         if (ctx.loggedUserStringAttribute() != null && !ctx.loggedUserStringAttribute().isEmpty()) {
-            LoggedUser loggedUser = this.userService.getLoggedOrSystem().transformToLoggedUser();
-            result.add(getObjectIdValue(loggedUser.getId()));
+            boolean hasIdAttribute = ctx.loggedUserStringAttribute().stream()
+                    .anyMatch(loggedUserCtx -> loggedUserCtx.LOGGED_USER_ID() != null);
+            if (hasIdAttribute) {
+                LoggedUser loggedUser = this.userService.getLoggedOrSystem().transformToLoggedUser();
+                result.add(getObjectIdValue(loggedUser.getId()));
+            }
         }
 
         return result;
@@ -538,6 +542,7 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
         Token op = ctx.inListStringComparison().op;
         boolean not = ctx.inListStringComparison().NOT() != null;
         checkOp(ComparisonType.ID, op);
+        List<ObjectId> objectIdList = handleObjectIdListComparison(ctx.inListStringComparison().stringList());
 
         switch (resourceType) {
             case PROCESS:
@@ -545,7 +550,7 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
                 break;
             case CASE:
                 qObjectId = QCase.case$._id;
-                List<String> stringIdList = handleStringListComparison(ctx.inListStringComparison().stringList());
+                List<String> stringIdList = objectIdList.stream().map(ObjectId::toString).collect(Collectors.toList());
                 setElasticQuery(ctx, buildElasticQueryInList("stringId", stringIdList, not));
                 break;
             case TASK:
@@ -558,7 +563,6 @@ public class QueryLangEvaluator extends QueryLangBaseListener {
                 throw new IllegalArgumentException("Unknown query type: " + resourceType);
         }
 
-        List<ObjectId> objectIdList = handleObjectIdListComparison(ctx.inListStringComparison().stringList());
         setMongoQuery(ctx, buildObjectIdPredicateInList(qObjectId, objectIdList, not));
     }
 

--- a/src/main/java/com/netgrif/application/engine/pfql/service/utils/SearchUtils.java
+++ b/src/main/java/com/netgrif/application/engine/pfql/service/utils/SearchUtils.java
@@ -1,5 +1,7 @@
 package com.netgrif.application.engine.pfql.service.utils;
 
+import com.netgrif.application.engine.auth.service.interfaces.IUserService;
+import com.netgrif.application.engine.configuration.ApplicationContextProvider;
 import com.netgrif.application.engine.petrinet.domain.QPetriNet;
 import com.netgrif.application.engine.petrinet.domain.version.QVersion;
 import com.netgrif.application.engine.petrinet.domain.version.Version;
@@ -161,7 +163,8 @@ public class SearchUtils {
             return explainQueryInternal(walker, query, errorListener);
         }
 
-        QueryLangEvaluator evaluator = new QueryLangEvaluator();
+        IUserService userService = (IUserService) ApplicationContextProvider.getBean(IUserService.class);
+        QueryLangEvaluator evaluator = new QueryLangEvaluator(userService);
         walker.walk(evaluator, query);
 
         return evaluator;

--- a/src/test/java/com/netgrif/application/engine/pfql/QueryLangTest.java
+++ b/src/test/java/com/netgrif/application/engine/pfql/QueryLangTest.java
@@ -1011,7 +1011,7 @@ public class QueryLangTest {
         assertEquals(expected, actual);
 
         // data value comparison
-        checkStringComparisonElastic("case", "data.field1.value", "dataSet.field1.textValue");
+        checkStringComparisonElastic("case", "data.field1.value", "dataSet.field1.fulltextValue");
 
         checkNumberComparisonElastic("case", "data.field2.value", "dataSet.field2.numberValue");
 
@@ -2034,7 +2034,12 @@ public class QueryLangTest {
 
     private static void checkStringComparisonElastic(String resource, String attribute, String resultAttribute) {
         String actual = evaluateQuery(String.format("%s: %s eq 'test'", resource, attribute)).getFullElasticQuery();
-        String expected = String.format("%s:test", resultAttribute);
+        String expected;
+        if (resultAttribute.matches("dataSet\\.[^.]*\\.fulltextValue")) {
+            expected = String.format("%s.keyword:test", resultAttribute);
+        } else {
+            expected = String.format("%s:test", resultAttribute);
+        }
 
         assertEquals(expected, actual);
 

--- a/src/test/java/com/netgrif/application/engine/pfql/QueryLangTest.java
+++ b/src/test/java/com/netgrif/application/engine/pfql/QueryLangTest.java
@@ -323,7 +323,14 @@ public class QueryLangTest {
 
         compareMongoQueries(mongoDbUtils, actual, expected);
 
-        actual = evaluateQuery(String.format("case: id in ('%s', '%s')", GENERIC_OBJECT_ID, GENERIC_OBJECT_ID)).getFullMongoQuery();
+        actual = evaluateQuery(String.format("case: id in ('%s', '%s', loggedUser.id, loggedUser.username, loggedUser.fullName)",
+                GENERIC_OBJECT_ID, GENERIC_OBJECT_ID)).getFullMongoQuery();
+        expected = QCase.case$._id.in(GENERIC_OBJECT_ID, GENERIC_OBJECT_ID, new ObjectId(systemUser.getId()));
+
+        compareMongoQueries(mongoDbUtils, actual, expected);
+
+        actual = evaluateQuery(String.format("case: id in ('%s', '%s', loggedUser.username, loggedUser.fullName)",
+                GENERIC_OBJECT_ID, GENERIC_OBJECT_ID)).getFullMongoQuery();
         expected = QCase.case$._id.in(GENERIC_OBJECT_ID, GENERIC_OBJECT_ID);
 
         compareMongoQueries(mongoDbUtils, actual, expected);
@@ -912,8 +919,12 @@ public class QueryLangTest {
 
         actual = evaluateQuery(String.format("case: id in ('%s', '%s', loggedUser.id, loggedUser.username, loggedUser.fullname)",
                 GENERIC_OBJECT_ID, GENERIC_OBJECT_ID)).getFullElasticQuery();
-        expected = String.format("stringId:(%s OR %s OR %s OR %s OR %s)", GENERIC_OBJECT_ID, GENERIC_OBJECT_ID,
-                systemUser.getId(), systemUser.getUsername(), systemUser.getFullName());
+        expected = String.format("stringId:(%s OR %s OR %s)", GENERIC_OBJECT_ID, GENERIC_OBJECT_ID, systemUser.getId());
+        assertEquals(expected, actual);
+
+        actual = evaluateQuery(String.format("case: id in ('%s', '%s', loggedUser.username, loggedUser.fullname)",
+                GENERIC_OBJECT_ID, GENERIC_OBJECT_ID)).getFullElasticQuery();
+        expected = String.format("stringId:(%s OR %s)", GENERIC_OBJECT_ID, GENERIC_OBJECT_ID);
         assertEquals(expected, actual);
 
         // processId comparison

--- a/src/test/java/com/netgrif/application/engine/pfql/QueryLangTest.java
+++ b/src/test/java/com/netgrif/application/engine/pfql/QueryLangTest.java
@@ -376,6 +376,22 @@ public class QueryLangTest {
 
         compareMongoQueries(mongoDbUtils, actual, expected);
 
+        actual = evaluateQuery("cases: title in ('test1' : loggedUser.username)").getFullMongoQuery();
+        expected = QCase.case$.title.gt("test1").and(QCase.case$.title.lt(systemUser.getUsername()));
+
+        compareMongoQueries(mongoDbUtils, actual, expected);
+
+        actual = evaluateQuery("cases: title in (loggedUser.username : 'test1')").getFullMongoQuery();
+        expected = QCase.case$.title.gt(systemUser.getUsername()).and(QCase.case$.title.lt("test1"));
+
+        compareMongoQueries(mongoDbUtils, actual, expected);
+
+        actual = evaluateQuery("cases: title in (loggedUser.username : loggedUser.fullName)").getFullMongoQuery();
+        expected = QCase.case$.title.gt(systemUser.getUsername()).and(QCase.case$.title.lt(systemUser.getFullName()));
+
+        compareMongoQueries(mongoDbUtils, actual, expected);
+
+
         // only available for elastic query
         // places comparison
         actual = evaluateQuery("case: places.p1.marking eq 1").getFullMongoQuery();
@@ -1013,6 +1029,21 @@ public class QueryLangTest {
 
         // data options comparison
         checkStringComparisonElastic("case", "data.field1.options", "dataSet.field1.options");
+
+        actual = evaluateQuery("cases: title in ('test1' : loggedUser.username)").getFullElasticQuery();
+        expected = String.format("(title:>test1 AND title:<%s)", systemUser.getUsername());
+
+        assertEquals(expected, actual);
+
+        actual = evaluateQuery("cases: title in (loggedUser.username : 'test1')").getFullElasticQuery();
+        expected = String.format("(title:>%s AND title:<test1)", systemUser.getUsername());
+
+        assertEquals(expected, actual);
+
+        actual = evaluateQuery("cases: title in (loggedUser.username : loggedUser.fullName)").getFullElasticQuery();
+        expected = String.format("(title:>%s AND title:<%s)", systemUser.getUsername(), systemUser.getFullName());
+
+        assertEquals(expected, actual);
     }
 
     @Test

--- a/src/test/java/com/netgrif/application/engine/pfql/QueryLangTest.java
+++ b/src/test/java/com/netgrif/application/engine/pfql/QueryLangTest.java
@@ -1,8 +1,11 @@
 package com.netgrif.application.engine.pfql;
 
 import com.netgrif.application.engine.TestHelper;
+import com.netgrif.application.engine.auth.domain.IUser;
+import com.netgrif.application.engine.auth.domain.LoggedUser;
 import com.netgrif.application.engine.auth.domain.QUser;
 import com.netgrif.application.engine.auth.domain.User;
+import com.netgrif.application.engine.auth.service.interfaces.IUserService;
 import com.netgrif.application.engine.petrinet.domain.PetriNet;
 import com.netgrif.application.engine.petrinet.domain.QPetriNet;
 import com.netgrif.application.engine.petrinet.domain.version.Version;
@@ -19,7 +22,6 @@ import com.querydsl.core.types.dsl.DateTimePath;
 import com.querydsl.core.types.dsl.StringPath;
 import org.bson.Document;
 import org.bson.types.ObjectId;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -61,9 +63,11 @@ public class QueryLangTest {
     @Autowired
     private TestHelper testHelper;
 
+    @Autowired
+    private IUserService userService;
+
     @Test
     @SuppressWarnings("unchecked")
-    @Disabled
     public void testSearchService() {
         testHelper.truncateDbs();
 
@@ -107,6 +111,9 @@ public class QueryLangTest {
 
         cases = searchService.search("cases: processIdentifier eq 'query_test'    and data.boolean_0.value == true and data.text_0.value != '4'");
         assertEquals(4, ((Page<Case>) cases).getTotalElements());
+
+        cases = searchService.search("cases: processIdentifier eq 'query_test' and author eq loggedUser.id");
+        assertEquals(10, ((Page<Case>) cases).getTotalElements());
     }
 
     @Test
@@ -238,6 +245,12 @@ public class QueryLangTest {
 
         compareMongoQueries(mongoDbUtils, actual, expected);
 
+        IUser systemUser = userService.getSystem();
+        actual = evaluateQuery("process: id neq loggedUser.id").getFullMongoQuery();
+        expected = QPetriNet.petriNet._id.eq(new ObjectId(systemUser.getStringId())).not();
+
+        compareMongoQueries(mongoDbUtils, actual, expected);
+
         // and comparison
         actual = evaluateQuery(String.format("process: id eq '%s' and title eq 'test'", GENERIC_OBJECT_ID)).getFullMongoQuery();
         expected = QPetriNet.petriNet._id.eq(GENERIC_OBJECT_ID).and(QPetriNet.petriNet.title.defaultValue.eq("test"));
@@ -304,6 +317,12 @@ public class QueryLangTest {
 
         compareMongoQueries(mongoDbUtils, actual, expected);
 
+        LoggedUser systemUser = userService.getSystem().transformToLoggedUser();
+        actual = evaluateQuery("case: id neq loggedUser.id").getFullMongoQuery();
+        expected = QCase.case$._id.eq(new ObjectId(systemUser.getId())).not();
+
+        compareMongoQueries(mongoDbUtils, actual, expected);
+
         actual = evaluateQuery(String.format("case: id in ('%s', '%s')", GENERIC_OBJECT_ID, GENERIC_OBJECT_ID)).getFullMongoQuery();
         expected = QCase.case$._id.in(GENERIC_OBJECT_ID, GENERIC_OBJECT_ID);
 
@@ -335,13 +354,18 @@ public class QueryLangTest {
 
         compareMongoQueries(mongoDbUtils, actual, expected);
 
+        actual = evaluateQuery("case: author eq loggedUser.id").getFullMongoQuery();
+        expected = QCase.case$.author.id.eq(systemUser.getId());
+
+        compareMongoQueries(mongoDbUtils, actual, expected);
+
         actual = evaluateQuery("case: author contains 'test'").getFullMongoQuery();
         expected = QCase.case$.author.id.contains("test");
 
         compareMongoQueries(mongoDbUtils, actual, expected);
 
-        actual = evaluateQuery("case: author in ('test', 'test1')").getFullMongoQuery();
-        expected = QCase.case$.author.id.in("test", "test1");
+        actual = evaluateQuery("case: author in ('test', 'test1', loggedUser.id, loggedUser.username, loggedUser.fullName)").getFullMongoQuery();
+        expected = QCase.case$.author.id.in("test", "test1", systemUser.getId(), systemUser.getUsername(), systemUser.getFullName());
 
         compareMongoQueries(mongoDbUtils, actual, expected);
 
@@ -459,8 +483,11 @@ public class QueryLangTest {
         compareMongoQueries(mongoDbUtils, actual, expected);
 
         // parenthesis comparison
-        actual = evaluateQuery(String.format("case: id eq '%s' and (title eq 'test' or title eq 'test1')", GENERIC_OBJECT_ID)).getFullMongoQuery();
-        expected = QCase.case$._id.eq(GENERIC_OBJECT_ID).and(QCase.case$.title.eq("test").or(QCase.case$.title.eq("test1")));
+        LoggedUser systemUser = userService.getSystem().transformToLoggedUser();
+        actual = evaluateQuery(String.format("case: id eq '%s' and (title eq 'test' or title eq 'test1' or title eq loggedUser.username)",
+                GENERIC_OBJECT_ID)).getFullMongoQuery();
+        expected = QCase.case$._id.eq(GENERIC_OBJECT_ID)
+                .and(QCase.case$.title.eq("test").or(QCase.case$.title.eq("test1")).or(QCase.case$.title.eq(systemUser.getUsername())));
 
         compareMongoQueries(mongoDbUtils, actual, expected);
 
@@ -489,8 +516,9 @@ public class QueryLangTest {
 
         compareMongoQueries(mongoDbUtils, actual, expected);
 
-        actual = evaluateQuery(String.format("task: id in ('%s', '%s')", GENERIC_OBJECT_ID, GENERIC_OBJECT_ID)).getFullMongoQuery();
-        expected = QTask.task._id.in(GENERIC_OBJECT_ID, GENERIC_OBJECT_ID);
+        LoggedUser systemUser = userService.getSystem().transformToLoggedUser();
+        actual = evaluateQuery(String.format("task: id in ('%s', '%s', loggedUser.id)", GENERIC_OBJECT_ID, GENERIC_OBJECT_ID)).getFullMongoQuery();
+        expected = QTask.task._id.in(GENERIC_OBJECT_ID, GENERIC_OBJECT_ID, new ObjectId(systemUser.getId()));
 
         compareMongoQueries(mongoDbUtils, actual, expected);
 
@@ -654,8 +682,14 @@ public class QueryLangTest {
 
         compareMongoQueries(mongoDbUtils, actual, expected);
 
-        actual = evaluateQuery(String.format("user: id in ('%s', '%s')", GENERIC_OBJECT_ID, GENERIC_OBJECT_ID)).getFullMongoQuery();
-        expected = QUser.user._id.in(GENERIC_OBJECT_ID, GENERIC_OBJECT_ID);
+        LoggedUser systemUser = userService.getSystem().transformToLoggedUser();
+        actual = evaluateQuery("user: id eq loggedUser.id").getFullMongoQuery();
+        expected = QUser.user._id.eq(new ObjectId(systemUser.getId()));
+
+        compareMongoQueries(mongoDbUtils, actual, expected);
+
+        actual = evaluateQuery(String.format("user: id in ('%s', '%s', loggEduser.id)", GENERIC_OBJECT_ID, GENERIC_OBJECT_ID)).getFullMongoQuery();
+        expected = QUser.user._id.in(GENERIC_OBJECT_ID, GENERIC_OBJECT_ID, new ObjectId(systemUser.getId()));
 
         compareMongoQueries(mongoDbUtils, actual, expected);
 
@@ -687,6 +721,12 @@ public class QueryLangTest {
         // and comparison
         actual = evaluateQuery(String.format("user: id eq '%s' and email eq 'test'", GENERIC_OBJECT_ID)).getFullMongoQuery();
         expected = QUser.user._id.eq(GENERIC_OBJECT_ID).and(QUser.user.email.eq("test"));
+
+        compareMongoQueries(mongoDbUtils, actual, expected);
+
+        LoggedUser systemUser = userService.getSystem().transformToLoggedUser();
+        actual = evaluateQuery(String.format("user: id eq '%s' and email eq loggedUser.username", GENERIC_OBJECT_ID)).getFullMongoQuery();
+        expected = QUser.user._id.eq(GENERIC_OBJECT_ID).and(QUser.user.email.eq(systemUser.getUsername()));
 
         compareMongoQueries(mongoDbUtils, actual, expected);
 
@@ -865,8 +905,15 @@ public class QueryLangTest {
         expected = String.format("stringId:%s", GENERIC_OBJECT_ID);
         assertEquals(expected, actual);
 
-        actual = evaluateQuery(String.format("case: id in ('%s', '%s')", GENERIC_OBJECT_ID, GENERIC_OBJECT_ID)).getFullElasticQuery();
-        expected = String.format("stringId:(%s OR %s)", GENERIC_OBJECT_ID, GENERIC_OBJECT_ID);
+        LoggedUser systemUser = userService.getSystem().transformToLoggedUser();
+        actual = evaluateQuery("case: id neq loggedUser.id").getFullElasticQuery();
+        expected = String.format("NOT stringId:%s", systemUser.getId());
+        assertEquals(expected, actual);
+
+        actual = evaluateQuery(String.format("case: id in ('%s', '%s', loggedUser.id, loggedUser.username, loggedUser.fullname)",
+                GENERIC_OBJECT_ID, GENERIC_OBJECT_ID)).getFullElasticQuery();
+        expected = String.format("stringId:(%s OR %s OR %s OR %s OR %s)", GENERIC_OBJECT_ID, GENERIC_OBJECT_ID,
+                systemUser.getId(), systemUser.getUsername(), systemUser.getFullName());
         assertEquals(expected, actual);
 
         // processId comparison
@@ -892,12 +939,21 @@ public class QueryLangTest {
         expected = "author:test";
         assertEquals(expected, actual);
 
+        actual = evaluateQuery("case: author eq loggedUser.id").getFullElasticQuery();
+        expected = String.format("author:%s", systemUser.getId());
+        assertEquals(expected, actual);
+
         actual = evaluateQuery("case: author contains 'test'").getFullElasticQuery();
         expected = "author:*test*";
         assertEquals(expected, actual);
 
-        actual = evaluateQuery(String.format("case: author in ('%s', '%s')", GENERIC_OBJECT_ID, GENERIC_OBJECT_ID)).getFullElasticQuery();
-        expected = String.format("author:(%s OR %s)", GENERIC_OBJECT_ID, GENERIC_OBJECT_ID);
+        actual = evaluateQuery("case: author contains loggedUser.id").getFullElasticQuery();
+        expected = String.format("author:*%s*", systemUser.getId());
+        assertEquals(expected, actual);
+
+        actual = evaluateQuery(String.format("case: author in ('%s', '%s', loggedUser.id)", GENERIC_OBJECT_ID,
+                GENERIC_OBJECT_ID)).getFullElasticQuery();
+        expected = String.format("author:(%s OR %s OR %s)", GENERIC_OBJECT_ID, GENERIC_OBJECT_ID, new ObjectId(systemUser.getId()));
         assertEquals(expected, actual);
 
         // places comparison
@@ -934,6 +990,10 @@ public class QueryLangTest {
 
         actual = evaluateQuery("case: data.field1.value eq true").getFullElasticQuery();
         expected = "dataSet.field1.booleanValue:true";
+        assertEquals(expected, actual);
+
+        actual = evaluateQuery("case: data.field1.value eq loggedUser.anonymous").getFullElasticQuery();
+        expected = "dataSet.field1.booleanValue:false";
         assertEquals(expected, actual);
 
         actual = evaluateQuery("case: data.field1.value eq false").getFullElasticQuery();
@@ -1715,6 +1775,8 @@ public class QueryLangTest {
         assertThrows(IllegalArgumentException.class, () -> evaluateQuery("case email eq 'test'"));
         assertThrows(IllegalArgumentException.class, () -> evaluateQuery("case page 2"));
         assertThrows(IllegalArgumentException.class, () -> evaluateQuery("case:"));
+        assertThrows(IllegalArgumentException.class, () -> evaluateQuery("case: creationDate eq loggedUser.id"));
+        assertThrows(IllegalArgumentException.class, () -> evaluateQuery("case: processIdentifier eq loggedUser.anonymous"));
     }
 
     @Test

--- a/src/test/java/com/netgrif/application/engine/pfql/QueryLangTest.java
+++ b/src/test/java/com/netgrif/application/engine/pfql/QueryLangTest.java
@@ -68,7 +68,7 @@ public class QueryLangTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testSearchService() {
+    public void testSearchService() throws InterruptedException {
         testHelper.truncateDbs();
 
         Optional<PetriNet> optionalPetriNet = helper.createNet("/pfql.xml");
@@ -84,6 +84,8 @@ public class QueryLangTest {
             params.put("id", String.valueOf(i));
             helper.createCase(String.format("Test %02d", i), process, params);
         }
+
+        Thread.sleep(2000);
 
         Object cases = searchService.search("cases: processIdentifier eq 'query_test' page 1 size 5 sort by title desc");
         assertNotNull(cases);


### PR DESCRIPTION
# Description

Added placeholders `loggedUser.id`, `loggedUser.username`, `loggedUser.fullName` and `loggedUser.anonymous`. The placeholders can be used:
- anywhere in string comparisons (also in list, in range) (expect `.anonymous`)
- anywhere in boolean comparisons (only `.anonymous`) 
- anywhere in object id comparisons (only `.id`)

Implements [NAE-2460]

## Dependencies

No new dependencies were introduced

### Third party dependencies

No new dependencies were introduced

### Blocking Pull requests

There are no dependencies on other PR

## How Has Been This Tested?

By unit test: `QueryLangTest`

### Test Configuration

| Name                | Tested on |
|---------------------| --------- |
| OS                  |  Ubuntu 24.04.1 LTS |
| Runtime             |  Java 11  |
| Dependency Manager  |   Maven 3.6.3  |
| Framework version   |    Spring Boot 2.7.8  |
| Run parameters      |           |
| Other configuration |           |


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My changes have been checked, personally or remotely, with @...
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes:
    - [ ] Lint test
    - [x] Unit tests
    - [ ] Integration tests
- [ ] I have checked my contribution with code analysis tools:
    - [ ] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_application-engine)
    - [ ] [Snyk](https://app.snyk.io/org/netgrif/project/ea82b3b8-658d-41f5-89a7-76cd600da01f)
- [ ] I have made corresponding changes to the documentation:
    - [ ] Developer documentation
    - [ ] User Guides
    - [ ] Migration Guides


[NAE-2460]: https://netgrif.atlassian.net/browse/NAE-2460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for “logged user” placeholders in PFQL queries (ID, full name, username, and anonymous status), including within comparisons, lists, and ranges.

* **Bug Fixes**
  * PFQL query generation now resolves logged-user placeholders into concrete values correctly for both MongoDB and Elastic conditions.
  * Improved handling of logged-anonymous comparisons.

* **Tests**
  * Enabled and expanded coverage for logged-user placeholder behavior across MongoDB and Elastic, including added negative validation cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->