### PR TITLE
[NAE-2470] - PFQL double quote string support

### DIFF
--- a/src/main/java/com/netgrif/application/engine/pfql/domain/antlr4/QueryLang.g4
+++ b/src/main/java/com/netgrif/application/engine/pfql/domain/antlr4/QueryLang.g4
@@ -339,7 +339,7 @@ doubleRange: leftEndpoint=('(' | '[') SPACE? DOUBLE SPACE? ':' SPACE? DOUBLE SPA
 dateRange: leftEndpoint=('(' | '[') SPACE? DATE SPACE? ':' SPACE? DATE SPACE? rightEndpoint=(')' | ']') ;
 dateTimeRange: leftEndpoint=('(' | '[') SPACE? DATETIME SPACE? ':' SPACE? DATETIME SPACE? rightEndpoint=(')' | ']') ;
 versionRange: leftEndpoint=('(' | '[') SPACE? VERSION_NUMBER SPACE? ':' SPACE? VERSION_NUMBER SPACE? rightEndpoint=(')' | ']') ;
-STRING: '\'' (~('\'' | '\r' | '\n'))* '\'' ; // todo NAE-1997: escape???
+STRING: '\'' ( '\\' . | ~('\'' | '\\' | '\r' | '\n') )* '\'' | '"'  ( '\\' . | ~('"'  | '\\'  | '\r' | '\n') )* '"';
 INT: DIGIT+ ;
 DOUBLE: DIGIT+ '.' DIGIT+ ;
 DATETIME: DATE 'T' ([01] DIGIT | '2' [0-3]) ':' [0-5] DIGIT ':' [0-5] DIGIT ('.' DIGIT+)? ; // 2020-03-03T20:00:00.055 // todo NAE-1997: format

--- a/src/main/java/com/netgrif/application/engine/pfql/service/utils/SearchUtils.java
+++ b/src/main/java/com/netgrif/application/engine/pfql/service/utils/SearchUtils.java
@@ -180,7 +180,7 @@ public class SearchUtils {
     }
 
     public static String getStringValue(String queryLangString) {
-        return queryLangString.replace("'", "");
+        return queryLangString.replaceAll("^[\"']+|[\"']+$", "");
     }
 
     public static ObjectId getObjectIdValue(String queryLangString) {

--- a/src/test/java/com/netgrif/application/engine/pfql/QueryLangTest.java
+++ b/src/test/java/com/netgrif/application/engine/pfql/QueryLangTest.java
@@ -92,6 +92,11 @@ public class QueryLangTest {
         assertEquals(PageImpl.class, cases.getClass());
         assertEquals(10, ((Page<Case>) cases).getTotalElements());
 
+        Object cases2 = searchService.search("cases: processIdentifier eq \"query_test\" page 1 size 5 sort by title desc");
+        assertNotNull(cases2);
+        assertEquals(PageImpl.class, cases2.getClass());
+        assertEquals(10, ((Page<Case>) cases2).getTotalElements());
+
         Object case3 = searchService.search("case: processIdentifier eq 'query_test' and data.number_0.value == 3");
         assertNotNull(case3);
         assertEquals(Case.class, case3.getClass());
@@ -102,6 +107,21 @@ public class QueryLangTest {
         assertNotNull(case4);
         assertEquals(Case.class, case4.getClass());
         assertEquals("4", ((Case) case4).getFieldValue("text_0"));
+
+        Object case4_2 = searchService.search("case: processIdentifier eq \"query_test\" and data.text_0.value == \"4\"");
+        assertNotNull(case4_2);
+        assertEquals(Case.class, case4_2.getClass());
+        assertEquals("4", ((Case) case4_2).getFieldValue("text_0"));
+
+        Object case4_3 = searchService.search("case: processIdentifier eq 'query_test' and data.text_0.value == \"4\"");
+        assertNotNull(case4_3);
+        assertEquals(Case.class, case4_3.getClass());
+        assertEquals("4", ((Case) case4_3).getFieldValue("text_0"));
+
+        Object case4_4 = searchService.search("case: processIdentifier eq \"query_test\" and data.text_0.value == '4'");
+        assertNotNull(case4_4);
+        assertEquals(Case.class, case4_4.getClass());
+        assertEquals("4", ((Case) case4_4).getFieldValue("text_0"));
 
         Object case5 = searchService.search("case: processIdentifier eq 'query_test' and data.boolean_0.value == true");
         assertNotNull(case5);


### PR DESCRIPTION
# Description

Implements [NAE-2470]
- update PFQL grammar to support double quote strings
- add new queries to QueryLangTest.java
- update SearchUtils to support double quote strings

## How Has Been This Tested?

Manually and also adding new queries to existing PFQL test

# Checklist:

- [*] My code follows the style guidelines of this project
- [*] I have performed a self-review of my own code
- [ ] My changes have been checked, personally or remotely, with @...
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have resolved all conflicts with the target branch of the PR
- [ ] I have updated and synced my code with the target branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes:
    - [ ] Lint test
    - [*] Unit tests
    - [ ] Integration tests
- [ ] I have checked my contribution with code analysis tools:
    - [ ] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_application-engine)
    - [ ] [Snyk](https://app.snyk.io/org/netgrif/project/ea82b3b8-658d-41f5-89a7-76cd600da01f)
- [ ] I have made corresponding changes to the documentation:
    - [ ] Developer documentation
    - [ ] User Guides
    - [ ] Migration Guides


[NAE-2470]: https://netgrif.atlassian.net/browse/NAE-2470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for single- and double-quoted text values in PFQL queries.
  * Escaped characters are supported within quoted values.

* **Bug Fixes**
  * Improved handling of quoted search values by removing only matching surrounding quotes.
  * Preserved quote characters within search text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->